### PR TITLE
Install zig in configure step

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-ghostty (1.0.1-0~ppa1) UNRELEASED; urgency=low
+ghostty (1.0.1-0~ppa3) UNRELEASED; urgency=low
 
   * https://ghostty.org/docs/install/release-notes/1-0-1
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: ghostty
 Section: utils
 Priority: optional
 Maintainer: Mike Kasberg <kasberg.mike@gmail.com>
-Build-Depends: debhelper-compat (= 13), libgtk-4-dev, libadwaita-1-dev, libonig-dev, libbz2-dev
+Build-Depends: debhelper-compat (= 13), libgtk-4-dev, libadwaita-1-dev, libonig-dev, libbz2-dev, wget
 Standards-Version: 4.6.1
 Homepage: https://ghostty.org/
 Rules-Requires-Root: no

--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,7 @@
 #!/usr/bin/make -f
+
+ZIG_VERSION = 0.13.0
+
 # You must remove unused comment lines for the released package.
 export DH_VERBOSE = 1
 #export DEB_BUILD_MAINT_OPTIONS = hardening=+all
@@ -9,6 +12,14 @@ export DH_VERBOSE = 1
 	dh $@
 
 override_dh_auto_configure:
+	# Install zig to /opt and symlink to /usr/local/bin as part of the "configure" step.
+	# This needs to be part of our build process because Ubuntu doesn't have an official
+	# zig package but we want to build on ubuntu PPA build servers.
+	wget "https://ziglang.org/download/$(ZIG_VERSION)/zig-linux-x86_64-$(ZIG_VERSION).tar.xz"
+	tar -xf "zig-linux-x86_64-$(ZIG_VERSION).tar.xz" -C /opt
+	rm "zig-linux-x86_64-$(ZIG_VERSION).tar.xz"
+	ln -s "/opt/zig-linux-x86_64-$(ZIG_VERSION)/zig" /usr/local/bin/zig
+	# And fetch the zig cache now.
 	ZIG_GLOBAL_CACHE_DIR=/tmp/offline-cache ./nix/build-support/fetch-zig-cache.sh
 
 override_dh_auto_build:

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -5,7 +5,6 @@
 set -e
 
 DEBIAN_FRONTEND="noninteractive"
-ZIG_VERSION="0.13.0"
 
 # Install Build Tools
 apt-get -qq update && apt-get -qq -y install build-essential debhelper devscripts pandoc libonig-dev libbz2-dev wget
@@ -14,11 +13,6 @@ wget -q "https://github.com/jedisct1/minisign/releases/download/0.11/minisign-0.
 tar -xzf minisign-0.11-linux.tar.gz
 mv minisign-linux/x86_64/minisign /usr/local/bin
 rm -r minisign-linux
-
-wget -q "https://ziglang.org/download/$ZIG_VERSION/zig-linux-x86_64-$ZIG_VERSION.tar.xz"
-tar -xf "zig-linux-x86_64-$ZIG_VERSION.tar.xz" -C /opt
-rm "zig-linux-x86_64-$ZIG_VERSION.tar.xz"
-ln -s "/opt/zig-linux-x86_64-$ZIG_VERSION/zig" /usr/local/bin/zig
 
 # Install Ghostty Dependencies
 apt-get -qq -y install libgtk-4-dev libadwaita-1-dev


### PR DESCRIPTION
I can't currently put this binary package in a PPA because the PPA server builds from source itself. That's a problem because the PPA build server is missing zig. We can work around this with a little "hack". Install zig to /opt an symlink to /usr/local/bin as part of the "configure" step.

Fixes #9