### PR TITLE
Let Ghostty be recognised by x-terminal-emulator

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -7,6 +7,7 @@ Package: ghostty
 Version: 1.0.1-0~ppa2
 Architecture: amd64
 Depends: libadwaita-1-0, libc6, libfontconfig1, libfreetype6, libglib2.0-0t64, libgtk-4-1, libharfbuzz0b, libonig5, libx11-6
+Provides: x-terminal-emulator
 Description: Fast, feature-rich, and cross-platform terminal emulator.
  Ghostty is a terminal emulator that differentiates itself by being fast,
  feature-rich, and native. While there are many excellent terminal emulators

--- a/DEBIAN/postinst
+++ b/DEBIAN/postinst
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+# Register Ghostty as an option for ubuntu default terminal
+update-alternatives --install /usr/bin/x-terminal-emulator x-terminal-emulator /usr/bin/ghostty 50

--- a/DEBIAN/postrm
+++ b/DEBIAN/postrm
@@ -2,6 +2,6 @@
 set -e
 
 # Remove Ghostty from ubuntu default terminal alternatives
-if [ "$1" = "remove" ] || [ "$1" = "purge" ]; then
+if [ "$1" = "remove" ]; then
     update-alternatives --remove x-terminal-emulator /usr/bin/ghostty
 fi

--- a/DEBIAN/postrm
+++ b/DEBIAN/postrm
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+# Remove Ghostty from ubuntu default terminal alternatives
+if [ "$1" = "remove" ] || [ "$1" = "purge" ]; then
+    update-alternatives --remove x-terminal-emulator /usr/bin/ghostty
+fi

--- a/build-ghostty.sh
+++ b/build-ghostty.sh
@@ -53,8 +53,9 @@ gzip -n -9 zig-out/usr/share/doc/ghostty/changelog.Debian
 gzip -n -9 zig-out/usr/share/man/man1/ghostty.1
 gzip -n -9 zig-out/usr/share/man/man5/ghostty.5
 
-## postinst is used by dpkg-deb; ensure it is executable
-chmod +x DEBIAN/postinst
+## postinst and postrm are used by dpkg-deb; ensure they are executable
+chmod +x zig-out/DEBIAN/postinst
+chmod +x zig-out/DEBIAN/postrm
 
 dpkg-deb --build zig-out ghostty_${FULL_VERSION}_amd64.deb
 mv ghostty_${FULL_VERSION}_amd64.deb ../

--- a/build-ghostty.sh
+++ b/build-ghostty.sh
@@ -53,5 +53,8 @@ gzip -n -9 zig-out/usr/share/doc/ghostty/changelog.Debian
 gzip -n -9 zig-out/usr/share/man/man1/ghostty.1
 gzip -n -9 zig-out/usr/share/man/man5/ghostty.5
 
+## postinst is used by dpkg-deb; ensure it is executable
+chmod +x DEBIAN/postinst
+
 dpkg-deb --build zig-out ghostty_${FULL_VERSION}_amd64.deb
 mv ghostty_${FULL_VERSION}_amd64.deb ../


### PR DESCRIPTION
This PR allows ghostty to be recognised by x-terminal-emulator, so users can more easily register it as their default terminal. This closes #14 

Sorry for the delay, I was travelling. Thanks for waiting though!