### PR TITLE
Fix zsh completion

### DIFF
--- a/build-ghostty.sh
+++ b/build-ghostty.sh
@@ -53,5 +53,10 @@ gzip -n -9 zig-out/usr/share/doc/ghostty/changelog.Debian
 gzip -n -9 zig-out/usr/share/man/man1/ghostty.1
 gzip -n -9 zig-out/usr/share/man/man5/ghostty.5
 
+# Zsh looks for /usr/local/share/zsh/site-functions/
+# but looks for /usr/share/zsh/vendor-completions/
+# (note the difference when we're not in /usr/local).
+mv zig-out/usr/share/zsh/site-functions zig-out/usr/share/zsh/vendor-completions
+
 dpkg-deb --build zig-out ghostty_${FULL_VERSION}_amd64.deb
 mv ghostty_${FULL_VERSION}_amd64.deb ../


### PR DESCRIPTION
Ghostty installs zsh completions to `zig-out/share/zsh/site-functions`. This is correct when installing to `/usr/local` since zsh on Ubuntu looks for completions at `/usr/local/zsh/site-functions`. But since we're building a .deb package, we install to `/usr`, and zsh on Ubuntu does not look for `/usr/share/zsh/site-functions`. Instead, it looks for `/usr/share/zsh/vendor-completions`. We should install our completions there and they will work correctly on Ubuntu.

Fixes #27