### PR TITLE
GitHub Action Workflow for Release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      release_version:
+        description: The git tag to release.
+        type: string
+        required: true
 
 permissions:
   contents: write
@@ -38,3 +43,34 @@ jobs:
           name: package-${{ matrix.ubuntu_version }}
           retention-days: 7
           path: ghostty_*.deb
+
+  release-ghostty:
+    name: (Pre-)Release Ghostty
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: build-ghostty
+    steps:
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: package-*
+          merge-multiple: true
+
+      - name: Validate Release Version
+        run: |
+          if ! head -n 1 debian/changelog | grep -q '${{ inputs.release_version }}'; then
+            echo "::error::Release version does not match changelog."
+            exit 1
+          else
+            # The git tag shouldn't have `~`
+            echo "RELEASE_TAG=$(echo '${{ inputs.release_version }}' | sed 's/~/-/g')" >> $GITHUB_ENV
+          fi
+
+      - name: Publish Release Draft
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          files: ghostty_*.deb
+          name: ${{ inputs.release_version }}
+          tag_name: ${{ env.RELEASE_TAG }}
+          fail_on_unmatched_files: true


### PR DESCRIPTION
In bf88a72, I ripped out the part of our workflow that pushes release artifacts as I was experimenting with a matrix build. Let's put that back now. As a separate build job that depends on the first, so we can include artifacts from all Ubuntu versions in the release.