### PR TITLE
Prepare for ppa3 release

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Mike Kasberg <kasberg.mike@gmail.com>
 Homepage: https://ghostty.org/
 Package: ghostty
-Version: 1.0.1-0~ppa2
+Version: 1.0.1-0~ppa3
 Architecture: amd64
 Depends: libadwaita-1-0, libc6, libfontconfig1, libfreetype6, libglib2.0-0t64, libgtk-4-1, libharfbuzz0b, libonig5, libx11-6
 Provides: x-terminal-emulator

--- a/build-ghostty.sh
+++ b/build-ghostty.sh
@@ -8,7 +8,7 @@ UBUNTU_VERSION=$(lsb_release -sr)
 UBUNTU_DIST=$(lsb_release -sc)
 
 #FULL_VERSION="$GHOSTTY_VERSION-0~${UBUNTU_DIST}1"
-FULL_VERSION="$GHOSTTY_VERSION-0~ppa2"
+FULL_VERSION="$GHOSTTY_VERSION-0~ppa3"
 
 
 # Fetch Ghostty Source
@@ -68,4 +68,4 @@ fi
 mv zig-out/usr/share/zsh/site-functions zig-out/usr/share/zsh/vendor-completions
 
 dpkg-deb --build zig-out ghostty_${FULL_VERSION}_amd64.deb
-mv ghostty_${FULL_VERSION}_amd64.deb ../
+mv ghostty_${FULL_VERSION}_amd64.deb ../ghostty_${FULL_VERSION}_amd64_${UBUNTU_VERSION}.deb

--- a/changelog.Debian
+++ b/changelog.Debian
@@ -1,3 +1,9 @@
+ghostty (1.0.1-0~ppa3) DIST; urgency=low
+
+  * Fix a regression on 22.04 where we had an incorrect dependency on ligblib-2.0-0t64 instead of libglib2.0-0
+
+ -- Mike Kasberg <kasberg.mike@gmail.com>  Tue, 31 Dec 2024 14:45:00 -0700
+
 ghostty (1.0.1-0~ppa2) DIST; urgency=low
 
   * Recognize Ghostty as an alternative for x-terminal-emulator


### PR DESCRIPTION
And tag our .deb packages with the version we built as part of the build step.