### PR TITLE
Update to add Debian Bookworm build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,15 @@ jobs:
     name: Build Ghostty
     strategy:
       matrix:
-        ubuntu_version: ["22.04", "24.04", "24.10"]
+        builds: 
+          - distro: "ubuntu"
+            version: "22.04"
+          - distro: "ubuntu"
+            version: "24.04"
+          - distro: "ubuntu"
+            version: "24.10"
+          - distro: "debian"
+            version: "bookworm"
     runs-on: ubuntu-latest
     steps:
         # See the docs: https://github.com/docker/build-push-action
@@ -32,9 +40,10 @@ jobs:
       - name: Build Docker Image
         uses: docker/build-push-action@v6
         with:
-          tags: ghostty-ubuntu:${{ matrix.ubuntu_version }}
+          tags: ghostty:${{ matrix.builds.distro }}-${{ matrix.builds.version }}
           build-args: |
-            UBUNTU_VERSION=${{ matrix.ubuntu_version }}
+            DISTRO=${{ matrix.builds.distro }}
+            DISTRO_VERSION=${{ matrix.builds.version }}
           push: false
           load: true
           cache-from: type=gha
@@ -44,16 +53,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build Ghostty
-        run: docker run --rm -v$PWD:/workspace -w /workspace ghostty-ubuntu:${{ matrix.ubuntu_version }} /bin/bash build-ghostty.sh
+        run: docker run --rm -v$PWD:/workspace -w /workspace ghostty:${{ matrix.builds.distro }}-${{ matrix.builds.version }} /bin/bash build-ghostty.sh
 
       - name: Lint .deb Package
         # Lintian shouldn't fail our build yet
-        run: docker run --rm -v$PWD:/workspace -w /workspace ghostty-ubuntu:${{ matrix.ubuntu_version }} lintian ghostty_*.deb || true 
+        run: docker run --rm -v$PWD:/workspace -w /workspace ghostty:${{ matrix.builds.distro }}-${{ matrix.builds.version }} lintian ghostty_*.deb || true 
         
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: package-${{ matrix.ubuntu_version }}
+          name: package-${{ matrix.builds.distro }}-${{ matrix.builds.version }}
           retention-days: 7
           path: ghostty_*.deb
 

--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -6,7 +6,7 @@ Homepage: https://ghostty.org/
 Package: ghostty
 Version: 1.0.1-0~ppa3
 Architecture: amd64
-Depends: libadwaita-1-0, libc6, libfontconfig1, libfreetype6, libglib2.0-0t64, libgtk-4-1, libharfbuzz0b, libonig5, libx11-6
+Depends: libadwaita-1-0, libc6, libfontconfig1, libfreetype6, libglib2.0-0t64 | libglib2.0-0, libgtk-4-1, libharfbuzz0b, libonig5, libx11-6
 Provides: x-terminal-emulator
 Description: Fast, feature-rich, and cross-platform terminal emulator.
  Ghostty is a terminal emulator that differentiates itself by being fast,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-ARG UBUNTU_VERSION="24.10"
-FROM ubuntu:${UBUNTU_VERSION}
+ARG DISTRO_VERSION="24.10"
+ARG DISTRO="ubuntu"
+FROM ${DISTRO}:${DISTRO_VERSION}
 
 # Install Build Tools
 RUN DEBIAN_FRONTEND="noninteractive" apt-get -qq update && \

--- a/build-ghostty.sh
+++ b/build-ghostty.sh
@@ -4,10 +4,10 @@ set -e
 
 GHOSTTY_VERSION="1.0.1"
 
-UBUNTU_VERSION=$(lsb_release -sr)
-UBUNTU_DIST=$(lsb_release -sc)
+DISTRO_VERSION=$(lsb_release -sr)
+DISTRO=$(lsb_release -sc)
 
-#FULL_VERSION="$GHOSTTY_VERSION-0~${UBUNTU_DIST}1"
+#FULL_VERSION="$GHOSTTY_VERSION-0~${DISTRO}1"
 FULL_VERSION="$GHOSTTY_VERSION-0~ppa3"
 
 # Fetch Ghostty Source
@@ -45,7 +45,7 @@ cp -r ../DEBIAN/ ./zig-out/DEBIAN/
 mkdir -p ./zig-out/usr/share/doc/ghostty/
 cp ../copyright ./zig-out/usr/share/doc/ghostty/
 cp ../changelog.Debian ./zig-out/usr/share/doc/ghostty/
-sed -i "s/DIST/$UBUNTU_DIST/" zig-out/usr/share/doc/ghostty/changelog.Debian
+sed -i "s/DIST/$DISTRO/" zig-out/usr/share/doc/ghostty/changelog.Debian
 gzip -n -9 zig-out/usr/share/doc/ghostty/changelog.Debian
 
 # Compress manpages
@@ -56,8 +56,8 @@ gzip -n -9 zig-out/usr/share/man/man5/ghostty.5
 chmod +x zig-out/DEBIAN/postinst
 chmod +x zig-out/DEBIAN/prerm
 
-# Package name changed after 22.04
-if [ "$UBUNTU_VERSION" = "22.04" ]; then
+# Package name changed after ubuntu 22.04
+if [ "$DISTRO" = "ubuntu" && "$DISTRO_VERSION" = "22.04" ]; then
   sed -i "s/libglib2.0-0t64/libglib2.0-0/" zig-out/DEBIAN/control
 fi
 
@@ -67,4 +67,4 @@ fi
 mv zig-out/usr/share/zsh/site-functions zig-out/usr/share/zsh/vendor-completions
 
 dpkg-deb --build zig-out ghostty_${FULL_VERSION}_amd64.deb
-mv ghostty_${FULL_VERSION}_amd64.deb ../ghostty_${FULL_VERSION}_amd64_${UBUNTU_VERSION}.deb
+mv ghostty_${FULL_VERSION}_amd64.deb ../ghostty_${FULL_VERSION}_amd64_${DISTRO_VERSION}.deb

--- a/build-ghostty.sh
+++ b/build-ghostty.sh
@@ -56,11 +56,6 @@ gzip -n -9 zig-out/usr/share/man/man5/ghostty.5
 chmod +x zig-out/DEBIAN/postinst
 chmod +x zig-out/DEBIAN/prerm
 
-# Package name changed after ubuntu 22.04
-if [ "$DISTRO" = "ubuntu" && "$DISTRO_VERSION" = "22.04" ]; then
-  sed -i "s/libglib2.0-0t64/libglib2.0-0/" zig-out/DEBIAN/control
-fi
-
 # Zsh looks for /usr/local/share/zsh/site-functions/
 # but looks for /usr/share/zsh/vendor-completions/
 # (note the difference when we're not in /usr/local).


### PR DESCRIPTION
To address issue #44 , I've come up with this pull request. It was easy enough to add debian bookworm build, but for older debian versions such as bullseye or buster, it will be a bit trickier because those versions do not have either `libadwaita-1-dev` nor `libgtk-4-dev`. I'll try to address those in a follow-up pull request