### PR TITLE
Add arm64 aka linux aarch64 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,24 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  # Repeated pushes to a PR will cancel all previous still running builds of the
+  # PR (for faster feedback), while multiple merges to main will not cancel.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build-ghostty:
     name: Build Ghostty
     strategy:
+      fail-fast: false
       matrix:
-        builds: 
+        arch:
+          - name: amd64
+            runner: ubuntu-24.04
+          - name: arm64
+            runner: ubuntu-24.04-arm
+        builds:
           - distro: "ubuntu"
             version: "22.04"
           - distro: "ubuntu"
@@ -29,7 +41,7 @@ jobs:
             version: "24.10"
           - distro: "debian"
             version: "bookworm"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.arch.runner }}
     steps:
         # See the docs: https://github.com/docker/build-push-action
       - name: Set up Docker Buildx
@@ -40,7 +52,7 @@ jobs:
       - name: Build Docker Image
         uses: docker/build-push-action@v6
         with:
-          tags: ghostty:${{ matrix.builds.distro }}-${{ matrix.builds.version }}
+          tags: ghostty:${{ matrix.builds.distro }}-${{ matrix.builds.version }}-${{ matrix.arch.name }}
           build-args: |
             DISTRO=${{ matrix.builds.distro }}
             DISTRO_VERSION=${{ matrix.builds.version }}
@@ -53,19 +65,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build Ghostty
-        run: docker run --rm -v$PWD:/workspace -w /workspace ghostty:${{ matrix.builds.distro }}-${{ matrix.builds.version }} /bin/bash build-ghostty.sh
+        run: docker run --rm -v$PWD:/workspace -w /workspace ghostty:${{ matrix.builds.distro }}-${{ matrix.builds.version }}-${{ matrix.arch.name }} /bin/bash build-ghostty.sh
 
       - name: Lint .deb Package
         # Lintian shouldn't fail our build yet
-        run: docker run --rm -v$PWD:/workspace -w /workspace ghostty:${{ matrix.builds.distro }}-${{ matrix.builds.version }} lintian ghostty_*.deb || true
+        run: docker run --rm -v$PWD:/workspace -w /workspace ghostty:${{ matrix.builds.distro }}-${{ matrix.builds.version }}-${{ matrix.arch.name }} lintian ghostty_*.deb || true
 
       - name: Test Installation
-        run: docker run --rm -v$PWD:/workspace -w /workspace ghostty:${{ matrix.builds.distro }}-${{ matrix.builds.version }} dpkg -i ghostty_*.deb
-        
+        run: docker run --rm -v$PWD:/workspace -w /workspace ghostty:${{ matrix.builds.distro }}-${{ matrix.builds.version }}-${{ matrix.arch.name }} dpkg -i ghostty_*.deb
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: package-${{ matrix.builds.distro }}-${{ matrix.builds.version }}
+          name: package-${{ matrix.builds.distro }}-${{ matrix.builds.version }}-${{ matrix.arch.name }}
           retention-days: 7
           path: ghostty_*.deb
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,16 +17,16 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get -qq update && \
 # https://jedisct1.github.io/minisign/
 RUN wget -q "https://github.com/jedisct1/minisign/releases/download/0.11/minisign-0.11-linux.tar.gz" && \
     tar -xzf minisign-0.11-linux.tar.gz && \
-    mv minisign-linux/x86_64/minisign /usr/local/bin && \
+    mv "minisign-linux/$(uname -m)/minisign" /usr/local/bin && \
     rm -r minisign-linux
 
 # Install zig
 # https://ziglang.org/download/
 ARG ZIG_VERSION="0.13.0"
-RUN wget -q "https://ziglang.org/download/$ZIG_VERSION/zig-linux-x86_64-$ZIG_VERSION.tar.xz" && \
-    tar -xf "zig-linux-x86_64-$ZIG_VERSION.tar.xz" -C /opt && \
-    rm "zig-linux-x86_64-$ZIG_VERSION.tar.xz" && \
-    ln -s "/opt/zig-linux-x86_64-$ZIG_VERSION/zig" /usr/local/bin/zig
+RUN wget -q "https://ziglang.org/download/$ZIG_VERSION/zig-linux-$(uname -m)-$ZIG_VERSION.tar.xz" && \
+    tar -xf "zig-linux-$(uname -m)-$ZIG_VERSION.tar.xz" -C /opt && \
+    rm "zig-linux-$(uname -m)-$ZIG_VERSION.tar.xz" && \
+    ln -s "/opt/zig-linux-$(uname -m)-$ZIG_VERSION/zig" /usr/local/bin/zig
 
 # Install Ghostty Dependencies
 RUN DEBIAN_FRONTEND="noninteractive" apt-get -qq update && \

--- a/build-ghostty.sh
+++ b/build-ghostty.sh
@@ -38,8 +38,16 @@ zig build \
   -Demit-docs \
   -Dversion-string=$GHOSTTY_VERSION
 
+UNAME_M="$(uname -m)"
+if [ "${UNAME_M}" = "x86_64" ]; then
+    DEBIAN_ARCH="amd64"
+elif [ "${UNAME_M}" = "aarch64" ]; then \
+    DEBIAN_ARCH="arm64"
+fi
+
 # Debian control files
 cp -r ../DEBIAN/ ./zig-out/DEBIAN/
+sed -i "s/amd64/$DEBIAN_ARCH/g" ./zig-out/DEBIAN/control
 
 # Changelog and copyright
 mkdir -p ./zig-out/usr/share/doc/ghostty/
@@ -61,5 +69,5 @@ chmod +x zig-out/DEBIAN/prerm
 # (note the difference when we're not in /usr/local).
 mv zig-out/usr/share/zsh/site-functions zig-out/usr/share/zsh/vendor-completions
 
-dpkg-deb --build zig-out ghostty_${FULL_VERSION}_amd64.deb
-mv ghostty_${FULL_VERSION}_amd64.deb ../ghostty_${FULL_VERSION}_amd64_${DISTRO_VERSION}.deb
+dpkg-deb --build zig-out "ghostty_${FULL_VERSION}_${DEBIAN_ARCH}.deb"
+mv "ghostty_${FULL_VERSION}_${DEBIAN_ARCH}.deb" "../ghostty_${FULL_VERSION}_${DEBIAN_ARCH}_${DISTRO_VERSION}.deb"


### PR DESCRIPTION
This adds arm64 builds for all Distros and uses the native linux-aarch64 Github Action runners for the arm64 builds, which is much faster than using qemu for emulating like the attempt in https://github.com/mkasberg/ghostty-ubuntu/pull/35

In theory also `any` or `amd64 arm64` (one space in between) should work as `Architecture` in `/DEBIAN/control`, but that didn't work when trying it. Thus using sed instead.

Also adding some concurrency configuration for fast PR feedback on multiple pushes (used that while working on https://github.com/dbast/ghostty-ubuntu/pull/1). Also setting up the matrix so that one failing job (due to e.g. a temporary download failure) doesn't cancel all the other matrix jobs.