### PR TITLE
Fix Build for 1.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,9 @@ jobs:
           - name: arm64
             runner: ubuntu-24.04-arm
         builds:
-          - distro: "ubuntu"
-            version: "22.04"
+          # Build errors with Ghostty 1.1. Can put this back when we fix the errors.
+          # - distro: "ubuntu"
+          #   version: "22.04"
           - distro: "ubuntu"
             version: "24.04"
           - distro: "ubuntu"

--- a/build-ghostty.sh
+++ b/build-ghostty.sh
@@ -22,7 +22,7 @@ tar -xzmf "ghostty-$GHOSTTY_VERSION.tar.gz"
 cd "ghostty-$GHOSTTY_VERSION"
 
 # On Ubuntu it's libbz2, not libbzip2
-sed -i 's/linkSystemLibrary2("bzip2", dynamic_link_opts)/linkSystemLibrary2("bz2", dynamic_link_opts)/' build.zig
+sed -i 's/linkSystemLibrary2("bzip2", dynamic_link_opts)/linkSystemLibrary2("bz2", dynamic_link_opts)/' src/build/SharedDeps.zig
 
 # Fetch Zig Cache
 ZIG_GLOBAL_CACHE_DIR=/tmp/offline-cache ./nix/build-support/fetch-zig-cache.sh


### PR DESCRIPTION
Ghostty 1.1.0 has moved the bzip2 dependency to SharedDeps.zig. Need to update our build script to handle that.

There are some other build errors with Ubuntu 22.04, let's remove that for now so we don't delay releasing this for 24.04+.