### PR TITLE
Build for 22.04 Again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,8 @@ jobs:
       fail-fast: false
       matrix:
         builds:
-          # Build errors with Ghostty 1.1. Can put this back when we fix the errors.
-          # - distro: "ubuntu"
-          #   version: "22.04"
+          - distro: "ubuntu"
+            version: "22.04"
           - distro: "ubuntu"
             version: "24.04"
           - distro: "ubuntu"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get -qq update && \
     libonig-dev \
     lintian \
     lsb-release \
-    minisign \
     pandoc \
     wget \
     # Ghostty Dependencies
@@ -19,6 +18,9 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get -qq update && \
     libgtk-4-dev && \
     # Clean up for better caching
     rm -rf /var/lib/apt/lists/*
+
+ADD install-minisign.sh .
+RUN bash install-minisign.sh
 
 # Install zig
 # https://ziglang.org/download/

--- a/build-ghostty.sh
+++ b/build-ghostty.sh
@@ -40,6 +40,14 @@ cd "ghostty-$GHOSTTY_VERSION"
 # On Ubuntu it's libbz2, not libbzip2
 sed -i 's/linkSystemLibrary2("bzip2", dynamic_link_opts)/linkSystemLibrary2("bz2", dynamic_link_opts)/' src/build/SharedDeps.zig
 
+if [ $(lsb_release -sr) = "22.04" ]; then
+  # Patch for older versions of some libs on ubuntu 22.04
+  # Generated like this (from ghostty git source):
+  # git diff -u > ../ghostty-ubuntu/ubuntu_22.04.patch
+  echo "Patch for Ubuntu 22.04"
+  patch -p1 < ../ubuntu_22.04.patch
+fi
+
 echo "Fetch Zig Cache"
 ZIG_GLOBAL_CACHE_DIR=/tmp/offline-cache ./nix/build-support/fetch-zig-cache.sh
 

--- a/install-minisign.sh
+++ b/install-minisign.sh
@@ -1,0 +1,20 @@
+# We want to isntall minisign via apt if possible for build security.
+# But it's not available that way in 22.04.
+
+set -e
+
+source /etc/os-release
+
+if [ $(lsb_release -sr) = "22.04" ]; then
+  DEBIAN_FRONTEND="noninteractive" apt-get -qq update
+  apt-get -qq -y --no-install-recommends install ca-certificates
+  rm -rf /var/lib/apt/lists/*
+  wget -q "https://github.com/jedisct1/minisign/releases/download/0.11/minisign-0.11-linux.tar.gz"
+  tar -xzf minisign-0.11-linux.tar.gz
+  mv "minisign-linux/$(uname -m)/minisign" /usr/local/bin
+  rm -r minisign-linux
+else
+  DEBIAN_FRONTEND="noninteractive" apt-get -qq update
+  apt-get -qq -y --no-install-recommends install minisign
+  rm -rf /var/lib/apt/lists/*
+fi

--- a/ubuntu_22.04.patch
+++ b/ubuntu_22.04.patch
@@ -1,0 +1,66 @@
+diff --git a/pkg/freetype/face.zig b/pkg/freetype/face.zig
+index eea3c685..f57f9af0 100644
+--- a/pkg/freetype/face.zig
++++ b/pkg/freetype/face.zig
+@@ -33,8 +33,8 @@ pub const Face = struct {
+ 
+     /// A macro that returns true whenever a face object contains an ‘sbix’
+     /// OpenType table and outline glyphs.
+-    pub fn hasSBIX(self: Face) bool {
+-        return c.FT_HAS_SBIX(self.handle);
++    pub fn hasSBIX(_: Face) bool {
++        return false;
+     }
+ 
+     /// A macro that returns true whenever a face object contains some
+diff --git a/pkg/oniguruma/errors.zig b/pkg/oniguruma/errors.zig
+index d63a481b..69cd2d51 100644
+--- a/pkg/oniguruma/errors.zig
++++ b/pkg/oniguruma/errors.zig
+@@ -44,7 +44,6 @@ pub const Error = error{
+     RetryLimitInMatchOver,
+     RetryLimitInSearchOver,
+     SubexpCallLimitInSearchOver,
+-    DefaultEncodingIsNotSet,
+     SpecifiedEncodingCantConvertToWideChar,
+     FailToInitialize,
+     InvalidArgument,
+@@ -67,7 +66,6 @@ pub const Error = error{
+     EndPatternWithUnmatchedParenthesis,
+     EndPatternInGroup,
+     UndefinedGroupOption,
+-    InvalidGroupOption,
+     InvalidPosixBracketType,
+     InvalidLookBehindPattern,
+     InvalidRepeatRangePattern,
+@@ -130,7 +128,6 @@ const error_code_map: []const struct { Error, c_int } = &.{
+     .{ Error.RetryLimitInMatchOver, c.ONIGERR_RETRY_LIMIT_IN_MATCH_OVER },
+     .{ Error.RetryLimitInSearchOver, c.ONIGERR_RETRY_LIMIT_IN_SEARCH_OVER },
+     .{ Error.SubexpCallLimitInSearchOver, c.ONIGERR_SUBEXP_CALL_LIMIT_IN_SEARCH_OVER },
+-    .{ Error.DefaultEncodingIsNotSet, c.ONIGERR_DEFAULT_ENCODING_IS_NOT_SET },
+     .{ Error.SpecifiedEncodingCantConvertToWideChar, c.ONIGERR_SPECIFIED_ENCODING_CANT_CONVERT_TO_WIDE_CHAR },
+     .{ Error.FailToInitialize, c.ONIGERR_FAIL_TO_INITIALIZE },
+     .{ Error.InvalidArgument, c.ONIGERR_INVALID_ARGUMENT },
+@@ -153,7 +150,6 @@ const error_code_map: []const struct { Error, c_int } = &.{
+     .{ Error.EndPatternWithUnmatchedParenthesis, c.ONIGERR_END_PATTERN_WITH_UNMATCHED_PARENTHESIS },
+     .{ Error.EndPatternInGroup, c.ONIGERR_END_PATTERN_IN_GROUP },
+     .{ Error.UndefinedGroupOption, c.ONIGERR_UNDEFINED_GROUP_OPTION },
+-    .{ Error.InvalidGroupOption, c.ONIGERR_INVALID_GROUP_OPTION },
+     .{ Error.InvalidPosixBracketType, c.ONIGERR_INVALID_POSIX_BRACKET_TYPE },
+     .{ Error.InvalidLookBehindPattern, c.ONIGERR_INVALID_LOOK_BEHIND_PATTERN },
+     .{ Error.InvalidRepeatRangePattern, c.ONIGERR_INVALID_REPEAT_RANGE_PATTERN },
+diff --git a/src/font/face/freetype.zig b/src/font/face/freetype.zig
+index b56e9469..ba85b973 100644
+--- a/src/font/face/freetype.zig
++++ b/src/font/face/freetype.zig
+@@ -284,10 +284,6 @@ pub const Face = struct {
+             .color = self.face.hasColor(),
+         }) catch return false;
+ 
+-        // If the glyph is SVG we assume colorized
+-        const glyph = self.face.handle.*.glyph;
+-        if (glyph.*.format == freetype.c.FT_GLYPH_FORMAT_SVG) return true;
+-
+         return false;
+     }
+ 


### PR DESCRIPTION
We stopped building for Ubuntu 22.04 in #58 because the build was broken. This commit builds for 22.04 again by applying a couple light patches to the Ghostty source to be compatible with older libraries in 22.04.