### PR TITLE
end2end integrity: Install minisign via apt-get, check zig signature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,34 +2,30 @@ ARG DISTRO_VERSION="24.10"
 ARG DISTRO="ubuntu"
 FROM ${DISTRO}:${DISTRO_VERSION}
 
-# Install Build Tools
+# Install Dependencies
 RUN DEBIAN_FRONTEND="noninteractive" apt-get -qq update && \
-    apt-get -qq -y install \
+    apt-get -qq -y --no-install-recommends install \
+    # Build Tools
     build-essential \
     libbz2-dev \
     libonig-dev \
     lintian \
     lsb-release \
+    minisign \
     pandoc \
-    wget
-
-# Install Minisign
-# https://jedisct1.github.io/minisign/
-RUN wget -q "https://github.com/jedisct1/minisign/releases/download/0.11/minisign-0.11-linux.tar.gz" && \
-    tar -xzf minisign-0.11-linux.tar.gz && \
-    mv "minisign-linux/$(uname -m)/minisign" /usr/local/bin && \
-    rm -r minisign-linux
+    wget \
+    # Ghostty Dependencies
+    libadwaita-1-dev \
+    libgtk-4-dev && \
+    # Clean up for better caching
+    rm -rf /var/lib/apt/lists/*
 
 # Install zig
 # https://ziglang.org/download/
 ARG ZIG_VERSION="0.13.0"
 RUN wget -q "https://ziglang.org/download/$ZIG_VERSION/zig-linux-$(uname -m)-$ZIG_VERSION.tar.xz" && \
+    wget -q "https://ziglang.org/download/$ZIG_VERSION/zig-linux-$(uname -m)-$ZIG_VERSION.tar.xz.minisig" && \
+    minisign -Vm "zig-linux-$(uname -m)-$ZIG_VERSION.tar.xz" -P "RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U" && \
     tar -xf "zig-linux-$(uname -m)-$ZIG_VERSION.tar.xz" -C /opt && \
-    rm "zig-linux-$(uname -m)-$ZIG_VERSION.tar.xz" && \
+    rm zig-linux-* && \
     ln -s "/opt/zig-linux-$(uname -m)-$ZIG_VERSION/zig" /usr/local/bin/zig
-
-# Install Ghostty Dependencies
-RUN DEBIAN_FRONTEND="noninteractive" apt-get -qq update && \
-    apt-get -qq -y install \
-    libadwaita-1-dev \
-    libgtk-4-dev

--- a/build-ghostty.sh
+++ b/build-ghostty.sh
@@ -10,7 +10,7 @@ DISTRO=$(lsb_release -sc)
 #FULL_VERSION="$GHOSTTY_VERSION-0~${DISTRO}1"
 FULL_VERSION="$GHOSTTY_VERSION-0~ppa1"
 
-# Fetch Ghostty Source
+echo "Fetch Ghostty Source"
 wget -q "https://release.files.ghostty.org/$GHOSTTY_VERSION/ghostty-$GHOSTTY_VERSION.tar.gz"
 wget -q "https://release.files.ghostty.org/$GHOSTTY_VERSION/ghostty-$GHOSTTY_VERSION.tar.gz.minisig"
 
@@ -24,10 +24,10 @@ cd "ghostty-$GHOSTTY_VERSION"
 # On Ubuntu it's libbz2, not libbzip2
 sed -i 's/linkSystemLibrary2("bzip2", dynamic_link_opts)/linkSystemLibrary2("bz2", dynamic_link_opts)/' src/build/SharedDeps.zig
 
-# Fetch Zig Cache
+echo "Fetch Zig Cache"
 ZIG_GLOBAL_CACHE_DIR=/tmp/offline-cache ./nix/build-support/fetch-zig-cache.sh
 
-# Build Ghostty with zig
+echo "Build Ghostty with zig"
 zig build \
   --summary all \
   --prefix ./zig-out/usr \
@@ -38,6 +38,7 @@ zig build \
   -Demit-docs \
   -Dversion-string=$GHOSTTY_VERSION
 
+echo "Setup Debian Package"
 UNAME_M="$(uname -m)"
 if [ "${UNAME_M}" = "x86_64" ]; then
     DEBIAN_ARCH="amd64"
@@ -70,5 +71,6 @@ chmod +x zig-out/DEBIAN/prerm
 # (note the difference when we're not in /usr/local).
 mv zig-out/usr/share/zsh/site-functions zig-out/usr/share/zsh/vendor-completions
 
+echo "Build Debian Package"
 dpkg-deb --build zig-out "ghostty_${FULL_VERSION}_${DEBIAN_ARCH}.deb"
 mv "ghostty_${FULL_VERSION}_${DEBIAN_ARCH}.deb" "../ghostty_${FULL_VERSION}_${DEBIAN_ARCH}_${DISTRO_VERSION}.deb"


### PR DESCRIPTION
While minisign is used to verify the ghostty source code tarball download, the minisign + zig binaries are downloaded via wget without verifying their integrity.

This PR changes that by installing minisign via apt-get (which checks the checksum of downloaded packages before install) and by checking the zig binary integrity via minisign too.

Also for faster execution / lower layer size / better layer caching etc:
* merging the two apt-get calls into one
* adding `--no-install-recommends`
* converting some comments in build-ghostty.sh to `echo ..` calls to better see what is currently running during gh workflow runs

This unlocks the possibility to also build for more exotic architectures like arnv7a, ppc64le, riscv64 as minisign (via apt-get) and zig are are available for those while the previous minisign binary download only contained amd64/arm64 binaries.