### PR TITLE
Fix Incorrect zig-out prefix

### DIFF
--- a/build-ghostty.sh
+++ b/build-ghostty.sh
@@ -40,9 +40,9 @@ else
   BUILD_ARGS="-fno-sys=gtk4-layer-shell"
 fi
 
-zig build \
+DESTDIR=zig-out zig build \
   --summary all \
-  --prefix ./zig-out/usr \
+  --prefix /usr \
   --system /tmp/offline-cache/p \
   -Doptimize=ReleaseFast \
   -Dcpu=baseline \


### PR DESCRIPTION
Several installed config files are using paths like `./zig-out/usr/bin/ghostty` instead of `/usr/bin/ghostty`.

Fix this by setting `--prefix=/usr` and using `DESTDIR` to control build output.

https://github.com/ghostty-org/ghostty/blob/main/PACKAGING.md#build-options