### PR TITLE
Install Dependencies with apt-get

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -119,5 +119,5 @@ if [[ $EUID -ne 0 ]]; then
 else
   SUDO=""
 fi
-$SUDO dpkg -i "$GHOSTTY_DEB_FILE"
+$SUDO apt-get install -y ./"$GHOSTTY_DEB_FILE"
 rm "$GHOSTTY_DEB_FILE"


### PR DESCRIPTION
In our installer script, we were installing our .deb package with `dpkg -i`. This is a problem if ghostty (1.2.0) depends on libgtk4-layer-shell0 and it's not installed, as the user would then need to run `apt-get install -f` manually. Our installer should handle this automatically.

We can replace `dpkg -i` with `apt-get install ./...`, which will automatically resolve dependencies along the way.

Fixes #117