### PR TITLE
Revert "Remove Support for Ubuntu 22.04"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,8 @@ jobs:
       matrix:
         builds:
           - distro: "ubuntu"
+            version: "22.04"
+          - distro: "ubuntu"
             version: "24.04"
           - distro: "ubuntu"
             version: "25.04"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get -qq update && \
     libonig-dev \
     lintian \
     lsb-release \
-    minisign \
     pandoc \
     wget \
     # Ghostty Dependencies
@@ -29,6 +28,9 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get -qq update && \
     fi && \
     # Clean up for better caching
     rm -rf /var/lib/apt/lists/*
+
+ADD install-minisign.sh .
+RUN bash install-minisign.sh
 
 # Install zig
 # https://ziglang.org/download/

--- a/build-ghostty.sh
+++ b/build-ghostty.sh
@@ -29,6 +29,14 @@ cd "ghostty-$GHOSTTY_VERSION"
 # On Ubuntu it's libbz2, not libbzip2
 sed -i 's/linkSystemLibrary2("bzip2", dynamic_link_opts)/linkSystemLibrary2("bz2", dynamic_link_opts)/' src/build/SharedDeps.zig
 
+if [ "$DISTRO_VERSION" = "22.04" ]; then
+  # Patch for older versions of some libs on ubuntu 22.04
+  # Generated like this (from ghostty git source):
+  # git diff -u > ../ghostty-ubuntu/ubuntu_22.04.patch
+  echo "Patch for Ubuntu 22.04"
+  patch -p1 < ../ubuntu_22.04.patch
+fi
+
 echo "Fetch Zig Cache"
 ZIG_GLOBAL_CACHE_DIR=/tmp/offline-cache ./nix/build-support/fetch-zig-cache.sh
 

--- a/install-minisign.sh
+++ b/install-minisign.sh
@@ -1,0 +1,20 @@
+# We want to isntall minisign via apt if possible for build security.
+# But it's not available that way in 22.04.
+
+set -e
+
+source /etc/os-release
+
+if [ $(lsb_release -sr) = "22.04" ]; then
+  DEBIAN_FRONTEND="noninteractive" apt-get -qq update
+  apt-get -qq -y --no-install-recommends install ca-certificates
+  rm -rf /var/lib/apt/lists/*
+  wget -q "https://github.com/jedisct1/minisign/releases/download/0.11/minisign-0.11-linux.tar.gz"
+  tar -xzf minisign-0.11-linux.tar.gz
+  mv "minisign-linux/$(uname -m)/minisign" /usr/local/bin
+  rm -r minisign-linux
+else
+  DEBIAN_FRONTEND="noninteractive" apt-get -qq update
+  apt-get -qq -y --no-install-recommends install minisign
+  rm -rf /var/lib/apt/lists/*
+fi

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ ARCH=$(dpkg --print-architecture)
 
 case "$ID" in
   ubuntu|pop|tuxedo|neon)
-    if [[ "$VERSION_ID" =~ ^(25.04|24.04)$ ]]; then
+    if [[ "$VERSION_ID" =~ ^(25.04|24.04|22.04)$ ]]; then
       SUFFIX="${ARCH}_${VERSION_ID}"
     else
       echo "This installer is not compatible with Ubuntu $VERSION_ID"
@@ -31,7 +31,7 @@ case "$ID" in
     ;;
   
   elementary)
-    if [[ "$UBUNTU_VERSION_ID" =~ ^(25.04|24.04)$ ]]; then
+    if [[ "$UBUNTU_VERSION_ID" =~ ^(25.04|24.04|22.04)$ ]]; then
       SUFFIX="${ARCH}_${UBUNTU_VERSION_ID}"
     else
       echo "This installer is not compatible with Ubuntu $UBUNTU_VERSION_ID"
@@ -70,6 +70,7 @@ case "$ID" in
       declare -A SUPPORTED_VERSIONS=(
         ["plucky"]="25.04"
         ["noble"]="24.04"
+        ["jammy"]="22.04"
       )
 
       if [[ -n "${SUPPORTED_VERSIONS[$UBUNTU_CODENAME]}" ]]; then
@@ -82,7 +83,7 @@ case "$ID" in
     ;;
 
   *)
-    if [[ "$UBUNTU_VERSION_ID" =~ ^(25.04|24.04)$ ]]; then
+    if [[ "$UBUNTU_VERSION_ID" =~ ^(25.04|24.04|22.04)$ ]]; then
       SUFFIX="${ARCH}_${UBUNTU_VERSION_ID}"
     else
       echo "This install script is not compatible with $ID."

--- a/ubuntu_22.04.patch
+++ b/ubuntu_22.04.patch
@@ -1,0 +1,51 @@
+diff --git a/pkg/freetype/face.zig b/pkg/freetype/face.zig
+index 84178b860..9f872fcc2 100644
+--- a/pkg/freetype/face.zig
++++ b/pkg/freetype/face.zig
+@@ -33,8 +33,8 @@ pub const Face = struct {
+ 
+     /// A macro that returns true whenever a face object contains an ‘sbix’
+     /// OpenType table and outline glyphs.
+-    pub fn hasSBIX(self: Face) bool {
+-        return c.FT_HAS_SBIX(self.handle);
++    pub fn hasSBIX(_: Face) bool {
++        return false;
+     }
+ 
+     /// A macro that returns true whenever a face object contains some
+diff --git a/pkg/oniguruma/errors.zig b/pkg/oniguruma/errors.zig
+index d63a481b..69cd2d51 100644
+--- a/pkg/oniguruma/errors.zig
++++ b/pkg/oniguruma/errors.zig
+@@ -44,7 +44,6 @@ pub const Error = error{
+     RetryLimitInMatchOver,
+     RetryLimitInSearchOver,
+     SubexpCallLimitInSearchOver,
+-    DefaultEncodingIsNotSet,
+     SpecifiedEncodingCantConvertToWideChar,
+     FailToInitialize,
+     InvalidArgument,
+@@ -67,7 +66,6 @@ pub const Error = error{
+     EndPatternWithUnmatchedParenthesis,
+     EndPatternInGroup,
+     UndefinedGroupOption,
+-    InvalidGroupOption,
+     InvalidPosixBracketType,
+     InvalidLookBehindPattern,
+     InvalidRepeatRangePattern,
+@@ -130,7 +128,6 @@ const error_code_map: []const struct { Error, c_int } = &.{
+     .{ Error.RetryLimitInMatchOver, c.ONIGERR_RETRY_LIMIT_IN_MATCH_OVER },
+     .{ Error.RetryLimitInSearchOver, c.ONIGERR_RETRY_LIMIT_IN_SEARCH_OVER },
+     .{ Error.SubexpCallLimitInSearchOver, c.ONIGERR_SUBEXP_CALL_LIMIT_IN_SEARCH_OVER },
+-    .{ Error.DefaultEncodingIsNotSet, c.ONIGERR_DEFAULT_ENCODING_IS_NOT_SET },
+     .{ Error.SpecifiedEncodingCantConvertToWideChar, c.ONIGERR_SPECIFIED_ENCODING_CANT_CONVERT_TO_WIDE_CHAR },
+     .{ Error.FailToInitialize, c.ONIGERR_FAIL_TO_INITIALIZE },
+     .{ Error.InvalidArgument, c.ONIGERR_INVALID_ARGUMENT },
+@@ -153,7 +150,6 @@ const error_code_map: []const struct { Error, c_int } = &.{
+     .{ Error.EndPatternWithUnmatchedParenthesis, c.ONIGERR_END_PATTERN_WITH_UNMATCHED_PARENTHESIS },
+     .{ Error.EndPatternInGroup, c.ONIGERR_END_PATTERN_IN_GROUP },
+     .{ Error.UndefinedGroupOption, c.ONIGERR_UNDEFINED_GROUP_OPTION },
+-    .{ Error.InvalidGroupOption, c.ONIGERR_INVALID_GROUP_OPTION },
+     .{ Error.InvalidPosixBracketType, c.ONIGERR_INVALID_POSIX_BRACKET_TYPE },
+     .{ Error.InvalidLookBehindPattern, c.ONIGERR_INVALID_LOOK_BEHIND_PATTERN },
+     .{ Error.InvalidRepeatRangePattern, c.ONIGERR_INVALID_REPEAT_RANGE_PATTERN },


### PR DESCRIPTION
This reverts commit 935be49e73d2b49ffed9c8efe12eb0446a2584b0. This reverts commit 1f2da9d9def99bdc13ef595723a4f0e36dcf2f76.

We can re-add support for Ubuntu 22.04 (Ghostty 1.2+) if we can get this building again.