### PR TITLE
De-Duplicate Ghostty Version from control File

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -4,8 +4,8 @@ Priority: optional
 Maintainer: Mike Kasberg <kasberg.mike@gmail.com>
 Homepage: https://ghostty.org/
 Package: ghostty
-Version: 1.2.3-0~ppa1
-Architecture: amd64
+Version: DEBIAN_VERSION
+Architecture: DEBIAN_ARCH
 Depends: libadwaita-1-0, libc6, libfontconfig1, libfreetype6, libglib2.0-0t64 | libglib2.0-0, libgtk-4-1, libharfbuzz0b, libonig5, libx11-6
 Provides: x-terminal-emulator
 Description: Fast, feature-rich, and cross-platform terminal emulator.

--- a/build-ghostty.sh
+++ b/build-ghostty.sh
@@ -12,8 +12,7 @@ else
 fi
 DISTRO=$(lsb_release -sc)
 
-#FULL_VERSION="$GHOSTTY_VERSION-0~${DISTRO}1"
-FULL_VERSION="$GHOSTTY_VERSION-0~ppa1"
+DEBIAN_VERSION="$GHOSTTY_VERSION-0~ppa1"
 
 echo "Fetch Ghostty Source"
 wget -q "https://release.files.ghostty.org/$GHOSTTY_VERSION/ghostty-$GHOSTTY_VERSION.tar.gz"
@@ -61,7 +60,8 @@ fi
 
 # Debian control files
 cp -r ../DEBIAN/ ./zig-out/DEBIAN/
-sed -i "s/amd64/$DEBIAN_ARCH/g" ./zig-out/DEBIAN/control
+sed -i "s/DEBIAN_ARCH/$DEBIAN_ARCH/g" ./zig-out/DEBIAN/control
+sed -i "s/DEBIAN_VERSION/$DEBIAN_VERSION/g" ./zig-out/DEBIAN/control
 if [ "$DISTRO_VERSION" = "25.04" ] || [ "$DISTRO_VERSION" = "25.10" ]; then
   sed -i "s/Depends:/Depends: libgtk4-layer-shell0,/g" ./zig-out/DEBIAN/control
 fi
@@ -88,5 +88,5 @@ chmod +x zig-out/DEBIAN/prerm
 mv zig-out/usr/share/zsh/site-functions zig-out/usr/share/zsh/vendor-completions
 
 echo "Build Debian Package"
-dpkg-deb --build zig-out "ghostty_${FULL_VERSION}_${DEBIAN_ARCH}.deb"
-mv "ghostty_${FULL_VERSION}_${DEBIAN_ARCH}.deb" "../ghostty_${FULL_VERSION}_${DEBIAN_ARCH}_${DISTRO_VERSION}.deb"
+dpkg-deb --build zig-out "ghostty_${DEBIAN_VERSION}_${DEBIAN_ARCH}.deb"
+mv "ghostty_${DEBIAN_VERSION}_${DEBIAN_ARCH}.deb" "../ghostty_${DEBIAN_VERSION}_${DEBIAN_ARCH}_${DISTRO_VERSION}.deb"


### PR DESCRIPTION
Every time we update the version, we have to update it both in the build script and in the DEBIAN/control file. Let's make out build script write the control file as part of the build process so we only have to update it in one place.

This should also remove a roadblock for doing nightly builds more easily, since our build script will be the source of truth for the version.