### PR TITLE
Build Tip on Schedule

### DIFF
--- a/.github/workflows/build-tip.yml
+++ b/.github/workflows/build-tip.yml
@@ -1,0 +1,76 @@
+name: Build Ghostty Tip
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * *'
+
+permissions:
+  contents: write
+
+concurrency:
+  # Repeated pushes to a PR will cancel all previous still running builds of the
+  # PR (for faster feedback), while multiple merges to main will not cancel.
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-ghostty:
+    name: Build Ghostty Tip
+    strategy:
+      fail-fast: false
+      matrix:
+        builds:
+          - distro: "ubuntu"
+            version: "24.04"
+          - distro: "ubuntu"
+            version: "25.04"
+          - distro: "ubuntu"
+            version: "25.10"
+          - distro: "debian"
+            version: "trixie"
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+        # See the docs: https://github.com/docker/build-push-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+        # This action checks out the source as part of the action and can therefore
+        # go before the checkout step.
+      - name: Build Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          tags: ghostty:${{ matrix.builds.distro }}-${{ matrix.builds.version }}-${{ matrix.arch }}
+          build-args: |
+            DISTRO=${{ matrix.builds.distro }}
+            DISTRO_VERSION=${{ matrix.builds.version }}
+          push: false
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Checkout ghostty-ubuntu
+        uses: actions/checkout@v4
+
+      - name: Build Ghostty
+        run: docker run --rm -v$PWD:/workspace -w /workspace ghostty:${{ matrix.builds.distro }}-${{ matrix.builds.version }}-${{ matrix.arch }} /bin/bash build-ghostty.sh tip
+
+      - name: Lint .deb Package
+        # Lintian shouldn't fail our build yet
+        run: docker run --rm -v$PWD:/workspace -w /workspace ghostty:${{ matrix.builds.distro }}-${{ matrix.builds.version }}-${{ matrix.arch }} lintian ghostty_*.deb || true
+
+      - name: Test Installation
+        run: docker run --rm -v$PWD:/workspace -w /workspace ghostty:${{ matrix.builds.distro }}-${{ matrix.builds.version }}-${{ matrix.arch }} dpkg -i ghostty_*.deb
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-${{ matrix.builds.distro }}-${{ matrix.builds.version }}-${{ matrix.arch }}
+          retention-days: 7
+          path: ghostty_*.deb

--- a/build-ghostty.sh
+++ b/build-ghostty.sh
@@ -5,10 +5,18 @@ set -e
 # https://ghostty.org/docs/install/build
 GHOSTTY_VERSION="1.2.3"
 
-DEBIAN_SUFFIX="0~ppa1"
-SOURCE_FILENAME="ghostty-$GHOSTTY_VERSION"
-SOURCE_URL="https://release.files.ghostty.org/$GHOSTTY_VERSION/$SOURCE_FILENAME.tar.gz"
-MINISIG_URL="$SOURCE_URL.minisig"
+if [ "$1" == "tip" ]; then
+  DEBIAN_SUFFIX="0~nightly"
+  SOURCE_FILENAME="ghostty-source"
+  SOURCE_URL="https://github.com/ghostty-org/ghostty/releases/download/tip/$SOURCE_FILENAME.tar.gz"
+  MINISIG_URL="$SOURCE_URL.minisig"
+else
+  DEBIAN_SUFFIX="0~ppa1"
+  SOURCE_FILENAME="ghostty-$GHOSTTY_VERSION"
+  SOURCE_URL="https://release.files.ghostty.org/$GHOSTTY_VERSION/$SOURCE_FILENAME.tar.gz"
+  MINISIG_URL="$SOURCE_URL.minisig"
+fi
+
 
 # Use 25.04 format for ubuntu versions, "bookwork" format for Debian
 if [ $(lsb_release -si) = "Debian" ]; then
@@ -27,8 +35,11 @@ rm "$SOURCE_FILENAME.tar.gz.minisig"
 
 tar -xzmf "$SOURCE_FILENAME.tar.gz"
 
-cd "$SOURCE_FILENAME"
+cd ghostty-*/
 
+if [ "$1" == "tip" ]; then
+  GHOSTTY_VERSION=$(cat VERSION)
+fi
 
 # On Ubuntu it's libbz2, not libbzip2
 sed -i 's/linkSystemLibrary2("bzip2", dynamic_link_opts)/linkSystemLibrary2("bz2", dynamic_link_opts)/' src/build/SharedDeps.zig
@@ -63,7 +74,8 @@ elif [ "${UNAME_M}" = "aarch64" ]; then \
     DEBIAN_ARCH="arm64"
 fi
 
-DEBIAN_VERSION="$GHOSTTY_VERSION-$DEBIAN_SUFFIX"
+CLEAN_GHOSTTY_VERSION=$(echo "$GHOSTTY_VERSION" | sed "s/-/+/g")
+DEBIAN_VERSION="$CLEAN_GHOSTTY_VERSION-$DEBIAN_SUFFIX"
 
 # Debian control files
 cp -r ../DEBIAN/ ./zig-out/DEBIAN/


### PR DESCRIPTION
Building Ghostty tip on a schedule should help us be prepared for
upcoming versions by letting us know when the build breaks, ahead of the
next version being released, and therefore giving us time to fix it.