### PR TITLE
Make PPA Push Optional

### DIFF
--- a/.github/workflows/build-ppa-ghostty.yml
+++ b/.github/workflows/build-ppa-ghostty.yml
@@ -1,6 +1,7 @@
 name: Build Ghostty for PPA
 
 on:
+  pull_request:
   schedule:
     # Run daily at midnight UTC
     - cron: '0 0 * * *'
@@ -10,10 +11,15 @@ on:
         description: 'Version to build (default: tip)'
         required: false
         default: 'tip'
+      upload:
+        description: 'Upload to PPA (default: true)'
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   ghostty-build:
-    name: Build and Upload Ghostty
+    name: Build Ghostty
     runs-on: ubuntu-latest
     container:
       image: ubuntu:25.10
@@ -76,7 +82,24 @@ jobs:
           
           # Run the build script
           VERSION="${{ github.event.inputs.version || 'tip' }}"
-          .build-ppa/build-ghostty.sh "$VERSION"
+          ./build-ppa/build-ghostty.sh "$VERSION"
         env:
           DEBEMAIL: "kasberg.mike@gmail.com"
           DEBFULLNAME: "Mike Kasberg"
+
+      - name: Upload to PPA
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload == 'true')
+        run: |
+          # Set GPG passphrase if provided
+          if [ -n "${{ secrets.PPA_GPG_PASSPHRASE }}" ]; then
+            export GPG_TTY=$(tty)
+            echo "${{ secrets.PPA_GPG_PASSPHRASE }}" | gpg --passphrase-fd 0 --batch --no-tty --pinentry-mode loopback --clearsign --output /dev/null /dev/null
+          fi
+          
+          # Determine the package name based on version
+          VERSION="${{ github.event.inputs.version || 'tip' }}"
+          if [[ "$VERSION" == "tip" ]]; then
+            dput ppa:mkasberg/ghostty-ubuntu ghostty-nightly_*_source.changes
+          else
+            dput ppa:mkasberg/ghostty-ubuntu ghostty_*_source.changes
+          fi

--- a/.github/workflows/build-ppa-zig.yml
+++ b/.github/workflows/build-ppa-zig.yml
@@ -1,19 +1,17 @@
 name: Build Zig for PPA
 
 on:
-  schedule:
-    # Run daily at midnight UTC
-    - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version to build (default: tip)'
+      upload:
+        description: 'Upload to PPA (default: true)'
         required: false
-        default: 'tip'
+        default: true
+        type: boolean
 
 jobs:
   build:
-    name: Build and Upload Zig
+    name: Build Zig
     runs-on: ubuntu-latest
     container:
       image: ubuntu:25.10
@@ -69,8 +67,19 @@ jobs:
           fi
           
           # Run the build script
-          VERSION="${{ github.event.inputs.version || 'tip' }}"
-          ./build-ppa/build-zig.sh "$VERSION"
+          ./build-ppa/build-zig.sh
         env:
           DEBEMAIL: "kasberg.mike@gmail.com"
           DEBFULLNAME: "Mike Kasberg"
+
+      - name: Upload to PPA
+        if: github.event.inputs.upload == 'true'
+        run: |
+          # Set GPG passphrase if provided
+          if [ -n "${{ secrets.PPA_GPG_PASSPHRASE }}" ]; then
+            export GPG_TTY=$(tty)
+            echo "${{ secrets.PPA_GPG_PASSPHRASE }}" | gpg --passphrase-fd 0 --batch --no-tty --pinentry-mode loopback --clearsign --output /dev/null /dev/null
+          fi
+          
+          # Upload the Zig package
+          dput ppa:mkasberg/ghostty-ubuntu zig0.15_*_source.changes

--- a/build-ppa/build-ghostty.sh
+++ b/build-ppa/build-ghostty.sh
@@ -8,6 +8,9 @@
 
 set -e
 
+# Determine script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
     echo "Usage: $0 [version]"
     echo "  version: defaults to 'tip'"
@@ -16,15 +19,13 @@ if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
 fi
 
 VERSION=${1:-tip}
-PPA="ppa:mkasberg/ghostty-ubuntu"
 TIMESTAMP=$(date -u -R)
 
 echo "Building Ghostty for version: $VERSION"
-echo "PPA: $PPA"
 
 # Fetch the source and create .orig.tar.gz
 echo "Fetching Ghostty source..."
-./fetch-ghostty-orig-source.sh "$VERSION"
+"$SCRIPT_DIR/fetch-ghostty-orig-source.sh" "$VERSION"
 
 # Determine the base version and PPA number
 if [[ "$VERSION" == "tip" ]]; then
@@ -60,7 +61,7 @@ cp "${REPACK_TARBALL}" "$BUILD_DIR/"
 
 # Copy Debian packaging to temp directory
 echo "Copying Debian packaging..."
-cp -r "$PACKAGE_NAME/debian" "$BUILD_DIR/$UPSTREAM_DIR/"
+cp -r "$SCRIPT_DIR/$PACKAGE_NAME/debian" "$BUILD_DIR/$UPSTREAM_DIR/"
 
 # Update changelog in temp directory
 CHANGELOG_FILE="$BUILD_DIR/$UPSTREAM_DIR/debian/changelog"
@@ -89,10 +90,5 @@ echo "Moving build results and cleaning up..."
 mv "$BUILD_DIR"/${PACKAGE_NAME}_* ./
 rm -rf "$BUILD_DIR"
 
-# Upload to PPA
-echo "Uploading to PPA..."
-dput "$PPA" ${PACKAGE_NAME}_*_source.changes
-
-echo "Nightly build completed successfully!"
+echo "Build completed successfully!"
 echo "Version: $FULL_VERSION"
-echo "Uploaded to: $PPA"

--- a/build-ppa/build-zig.sh
+++ b/build-ppa/build-zig.sh
@@ -12,13 +12,11 @@ if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
     exit 0
 fi
 
-PPA="ppa:mkasberg/ghostty-ubuntu"
 TIMESTAMP=$(date -u -R)
 PACKAGE_NAME=zig0.15
 VERSION="0.15.2"
 
 echo "Building Zig for version: $VERSION"
-echo "PPA: $PPA"
 
 # Fetch the source and create .orig.tar.xz
 echo "Fetching Zig source..."
@@ -76,10 +74,5 @@ echo "Moving build results and cleaning up..."
 mv "$BUILD_DIR"/${PACKAGE_NAME}_* ./
 rm -rf "$BUILD_DIR"
 
-# Upload to PPA
-echo "Uploading to PPA..."
-dput "$PPA" ${PACKAGE_NAME}_*_source.changes
-
-echo "Nightly build completed successfully!"
+echo "Build completed successfully!"
 echo "Version: $FULL_VERSION"
-echo "Uploaded to: $PPA"


### PR DESCRIPTION
Make dput a separate step so we can test the build (on PRs, for example) without uploading to the PPA.

Also fix an issue with relative paths in the build script.