### PR TITLE
Fix PPA Build Workflow Signing

### DIFF
--- a/.github/workflows/ppa-build-ghostty.yml
+++ b/.github/workflows/ppa-build-ghostty.yml
@@ -98,7 +98,7 @@ jobs:
             echo "PPA_GPG_PASSPHRASE" | gpg --passphrase-fd 0 --batch --no-tty --pinentry-mode loopback --clearsign --output /dev/null /dev/null
           fi
           SIGN_OPT=""
-          if [[ "${{ inputs.upload }}" == 'true' ]]; then
+          if [ "${{ inputs.upload }}" = "true" ]; then
             SIGN_OPT="-s"
           fi
           

--- a/.github/workflows/ppa-build-zig.yml
+++ b/.github/workflows/ppa-build-zig.yml
@@ -87,7 +87,7 @@ jobs:
             echo "$PPA_GPG_PASSPHRASE" | gpg --passphrase-fd 0 --batch --no-tty --pinentry-mode loopback --clearsign --output /dev/null /dev/null
           fi
           SIGN_OPT=""
-          if [[ "${{ inputs.upload }}" == 'true' ]]; then
+          if [ "${{ inputs.upload }}" = "true" ]; then
             SIGN_OPT="-s"
           fi
           

--- a/build-ppa/build-ghostty.sh
+++ b/build-ppa/build-ghostty.sh
@@ -59,7 +59,7 @@ echo "Fetching Ghostty source..."
 "$SCRIPT_DIR/fetch-ghostty-orig-source.sh" "$VERSION"
 
 # Determine the base version and PPA number
-if [[ "$VERSION" == "tip" ]]; then
+if [ "$VERSION" = "tip" ]; then
     PACKAGE_NAME="ghostty-nightly"
     # Find the REPACK_TARBALL created by fetch-ghostty-orig-source.sh
     REPACK_TARBALL=$(ls ghostty-nightly_*+nightly*~ppa1.orig.tar.gz 2>/dev/null | head -n1)
@@ -113,7 +113,7 @@ head -n5 "$CHANGELOG_FILE"
 # Build the source package in temp directory
 echo "Building source package..."
 cd "$BUILD_DIR/$UPSTREAM_DIR"
-if [[ "$SIGN_PACKAGE" == 'true' ]]; then
+if [ "$SIGN_PACKAGE" = 'true' ]; then
   debuild -S -sa
 else
   debuild -S -sa -us -uc

--- a/build-ppa/build-zig.sh
+++ b/build-ppa/build-zig.sh
@@ -53,6 +53,7 @@ VERSION="0.15.2"
 
 echo "Building Zig for version: $VERSION"
 echo "Target codename: $CODENAME"
+echo "Sign package: $SIGN_PACKAGE"
 
 # Fetch the source and create .orig.tar.xz
 echo "Fetching Zig source..."
@@ -102,7 +103,7 @@ head -n5 "$CHANGELOG_FILE"
 # Build the source package in temp directory
 echo "Building source package..."
 cd "$BUILD_DIR/$UPSTREAM_DIR"
-if [[ "$SIGN_PACKAGE" == 'true' ]]; then
+if [ "$SIGN_PACKAGE" = "true" ]; then
   debuild -S -sa
 else
   debuild -S -sa -us -uc

--- a/build-ppa/fetch-ghostty-orig-source.sh
+++ b/build-ppa/fetch-ghostty-orig-source.sh
@@ -25,7 +25,7 @@ VERSION=${1:-tip}
 
 REPACK_SUFFIX="~ppa1"
 GHOSTTY_PUBKEY="RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV"
-if [[ "$VERSION" == "tip" ]]; then
+if [ "$VERSION" = "tip" ]; then
   PACKAGE_NAME="ghostty-nightly"
   GHOSTTY_TARBALL="ghostty-source.tar.gz"
   REPACK_TARBALL=""


### PR DESCRIPTION
Workflow signing was broken on PPA builds because we used `[[` in our
GitHub workflow shell script, but it was not running in bash --
ultimately resulting in the package not getting signed correctly.

Let's opt for compatibility here and fix the script.