### PR TITLE
Use Codename Suffix

### DIFF
--- a/build-ppa/build-ghostty.sh
+++ b/build-ppa/build-ghostty.sh
@@ -20,6 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CODENAME="questing"
 SIGN_PACKAGE=false
 VERSION="tip"
+PPA_VERSION="ppa1"
 
 # Parse command line arguments
 while getopts 'hc:sv:' opt; do
@@ -53,6 +54,8 @@ shift $((OPTIND - 1))
 TIMESTAMP=$(date -u -R)
 
 echo "Building Ghostty for version: $VERSION"
+echo "Ubuntu codename: $CODENAME"
+echo "Sign package: $SIGN_PACKAGE"
 
 # Fetch the source and create .orig.tar.gz
 echo "Fetching Ghostty source..."
@@ -62,17 +65,18 @@ echo "Fetching Ghostty source..."
 if [ "$VERSION" = "tip" ]; then
     PACKAGE_NAME="ghostty-nightly"
     # Find the REPACK_TARBALL created by fetch-ghostty-orig-source.sh
-    REPACK_TARBALL=$(ls ghostty-nightly_*+nightly*~ppa1.orig.tar.gz 2>/dev/null | head -n1)
+    REPACK_TARBALL=$(ls ghostty-nightly_*+nightly*~${PPA_VERSION}.orig.tar.gz 2>/dev/null | head -n1)
     if [ -z "$REPACK_TARBALL" ]; then
         echo "Error: Could not find repackaged tarball for tip build"
         exit 1
     fi
     # Extract FULL_VERSION from REPACK_TARBALL filename
     FULL_VERSION=$(echo "$REPACK_TARBALL" | sed -n 's/^ghostty-nightly_\([^)]*\)\.orig\.tar\.gz$/\1/p')
+    FULL_VERSION="${FULL_VERSION}-${CODENAME}1"
 else
     PACKAGE_NAME="ghostty"
-    FULL_VERSION="${VERSION}~ppa1"
-    REPACK_TARBALL="ghostty_${VERSION}~ppa1.orig.tar.gz"
+    FULL_VERSION="${VERSION}~${PPA_VERSION}-${CODENAME}1"
+    REPACK_TARBALL="ghostty_${VERSION}~${PPA_VERSION}.orig.tar.gz"
 fi
 
 echo "Full version: $FULL_VERSION"

--- a/build-ppa/build-zig.sh
+++ b/build-ppa/build-zig.sh
@@ -50,6 +50,7 @@ shift $((OPTIND - 1))
 TIMESTAMP=$(date -u -R)
 PACKAGE_NAME=zig0.15
 VERSION="0.15.2"
+PPA_VERSION="ppa4"
 
 echo "Building Zig for version: $VERSION"
 echo "Target codename: $CODENAME"
@@ -62,7 +63,7 @@ uscan --repack -v
 cd "$SCRIPT_DIR"
 
 # Determine the base version and PPA number
-FULL_VERSION="${VERSION}~us1-ppa3"
+FULL_VERSION="${VERSION}~us1-${PPA_VERSION}~${CODENAME}1"
 REPACK_TARBALL="zig0.15_${VERSION}~us1.orig.tar.xz"
 
 echo "Full version: $FULL_VERSION"


### PR DESCRIPTION
We can't upload source packages with different changelogs (for different ubuntu versions) with the same name to our PPA. Add a suffix for the Ubuntu codename to the full version number.