### PR TITLE
Fix bz2 Patch

### DIFF
--- a/build-ppa/ghostty-nightly/debian/patches/001-bzip2-to-bz2.patch
+++ b/build-ppa/ghostty-nightly/debian/patches/001-bzip2-to-bz2.patch
@@ -1,13 +1,13 @@
-diff --git c/src/build/SharedDeps.zig w/src/build/SharedDeps.zig
-index 77dec3350..2babf317d 100644
---- c/src/build/SharedDeps.zig
+diff --git i/src/build/SharedDeps.zig w/src/build/SharedDeps.zig
+index b1c084002..20a4161fa 100644
+--- i/src/build/SharedDeps.zig
 +++ w/src/build/SharedDeps.zig
-@@ -121,7 +121,7 @@ pub fn add(
-             );
+@@ -149,7 +149,7 @@ pub fn add(
+         );
  
-             if (b.systemIntegrationOption("freetype", .{})) {
--                step.linkSystemLibrary2("bzip2", dynamic_link_opts);
-+                step.linkSystemLibrary2("bz2", dynamic_link_opts);
-                 step.linkSystemLibrary2("freetype2", dynamic_link_opts);
-             } else {
-                 step.linkLibrary(freetype_dep.artifact("freetype"));
+         if (b.systemIntegrationOption("freetype", .{})) {
+-            step.linkSystemLibrary2("bzip2", dynamic_link_opts);
++            step.linkSystemLibrary2("bz2", dynamic_link_opts);
+             step.linkSystemLibrary2("freetype2", dynamic_link_opts);
+         } else {
+             step.linkLibrary(freetype_dep.artifact("freetype"));


### PR DESCRIPTION
Update the bz2 patch for debian/ubuntu so it applies cleanly after this change:

https://github.com/ghostty-org/ghostty/pull/10118