### PR TITLE
Don't fail fast on PPA Matrix

### DIFF
--- a/.github/workflows/ppa-build-ghostty.yml
+++ b/.github/workflows/ppa-build-ghostty.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(inputs.build_matrix) }}
     container:
       image: ${{ matrix.builds.container-image }}


### PR DESCRIPTION
We seem to get intermittent timeouts or even 503 in some cases when uploading to launchpad. Let's not cancel all the builds just because of one failed upload.