### PR TITLE
Patch Harfbuzz

### DIFF
--- a/build-binary/build-ghostty.sh
+++ b/build-binary/build-ghostty.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # https://ghostty.org/docs/install/build
 GHOSTTY_VERSION="1.2.3"
@@ -42,7 +43,9 @@ if [ "$1" == "tip" ]; then
 fi
 
 # On Ubuntu it's libbz2, not libbzip2
-sed -i 's/linkSystemLibrary2("bzip2", dynamic_link_opts)/linkSystemLibrary2("bz2", dynamic_link_opts)/' src/build/SharedDeps.zig
+patch -p1 < "$SCRIPT_DIR/patches/001-bzip2-to-bz2.patch"
+# Patch for our version of harfbuzz
+patch -p1 < "$SCRIPT_DIR/patches/002-harfbuzz.patch"
 
 echo "Fetch Zig Cache"
 ZIG_GLOBAL_CACHE_DIR=/tmp/offline-cache ./nix/build-support/fetch-zig-cache.sh

--- a/build-binary/patches/001-bzip2-to-bz2.patch
+++ b/build-binary/patches/001-bzip2-to-bz2.patch
@@ -1,0 +1,13 @@
+diff --git i/src/build/SharedDeps.zig w/src/build/SharedDeps.zig
+index b1c084002..20a4161fa 100644
+--- i/src/build/SharedDeps.zig
++++ w/src/build/SharedDeps.zig
+@@ -149,7 +149,7 @@ pub fn add(
+         );
+ 
+         if (b.systemIntegrationOption("freetype", .{})) {
+-            step.linkSystemLibrary2("bzip2", dynamic_link_opts);
++            step.linkSystemLibrary2("bz2", dynamic_link_opts);
+             step.linkSystemLibrary2("freetype2", dynamic_link_opts);
+         } else {
+             step.linkLibrary(freetype_dep.artifact("freetype"));

--- a/build-binary/patches/002-harfbuzz.patch
+++ b/build-binary/patches/002-harfbuzz.patch
@@ -1,0 +1,19 @@
+diff --git i/pkg/harfbuzz/buffer.zig w/pkg/harfbuzz/buffer.zig
+index b97c1bef4..dbb37887a 100644
+--- i/pkg/harfbuzz/buffer.zig
++++ w/pkg/harfbuzz/buffer.zig
+@@ -282,14 +282,6 @@ pub const ClusterLevel = enum(u2) {
+     /// the exact cluster values of each character, but is harder to use for
+     /// clients, since clusters might appear in any order.
+     characters = c.HB_BUFFER_CLUSTER_LEVEL_CHARACTERS,
+-
+-    /// In `graphemes`, non-base characters are merged into the cluster of the
+-    /// base character that precedes them. This is similar to the Unicode
+-    /// Grapheme Cluster algorithm, but it is not exactly the same. The output
+-    /// is not forced to be monotone. This is useful for clients that want to
+-    /// use HarfBuzz as a cheap implementation of the Unicode Grapheme Cluster
+-    /// algorithm.
+-    graphemes = c.HB_BUFFER_CLUSTER_LEVEL_GRAPHEMES,
+ };
+ 
+ /// The hb_glyph_info_t is the structure that holds information about the

--- a/build-ppa/ghostty-nightly/debian/patches/002-harfbuzz.patch
+++ b/build-ppa/ghostty-nightly/debian/patches/002-harfbuzz.patch
@@ -1,0 +1,19 @@
+diff --git i/pkg/harfbuzz/buffer.zig w/pkg/harfbuzz/buffer.zig
+index b97c1bef4..dbb37887a 100644
+--- i/pkg/harfbuzz/buffer.zig
++++ w/pkg/harfbuzz/buffer.zig
+@@ -282,14 +282,6 @@ pub const ClusterLevel = enum(u2) {
+     /// the exact cluster values of each character, but is harder to use for
+     /// clients, since clusters might appear in any order.
+     characters = c.HB_BUFFER_CLUSTER_LEVEL_CHARACTERS,
+-
+-    /// In `graphemes`, non-base characters are merged into the cluster of the
+-    /// base character that precedes them. This is similar to the Unicode
+-    /// Grapheme Cluster algorithm, but it is not exactly the same. The output
+-    /// is not forced to be monotone. This is useful for clients that want to
+-    /// use HarfBuzz as a cheap implementation of the Unicode Grapheme Cluster
+-    /// algorithm.
+-    graphemes = c.HB_BUFFER_CLUSTER_LEVEL_GRAPHEMES,
+ };
+ 
+ /// The hb_glyph_info_t is the structure that holds information about the

--- a/build-ppa/ghostty-nightly/debian/patches/series
+++ b/build-ppa/ghostty-nightly/debian/patches/series
@@ -1,1 +1,2 @@
 001-bzip2-to-bz2.patch
+002-harfbuzz.patch


### PR DESCRIPTION
We're getting an error on Ubuntu builds:

    pkg/harfbuzz/buffer.zig:292:18: error: root source file struct 'cimport' has no member named 'HB_BUFFER_CLUSTER_LEVEL_GRAPHEMES'
        graphemes = c.HB_BUFFER_CLUSTER_LEVEL_GRAPHEMES,
                    ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    .zig-cache/o/e54ea8e11cd4042106802b08d99b232a/cimport.zig:1:1: note: struct declared here
    pub const __builtin_bswap16 = https://github.com/import("std").zig.c_builtins.__builtin_bswap16;
    ^~~

Appears to have been introduced to Ghostty here:
https://github.com/ghostty-org/ghostty/pull/10332

Based on the Harfbuzz change here, which has not yet made it into the
Ubuntu version:
https://github.com/harfbuzz/harfbuzz/pull/5069

`ClusterLevel.graphemes` is unused, at least currently. Just delete it
so the build works.