### PR TITLE
Update patches (SharedDeps.zig, buffer.zig)

### DIFF
--- a/build-binary/patches/001-bzip2-to-bz2.patch
+++ b/build-binary/patches/001-bzip2-to-bz2.patch
@@ -2,9 +2,9 @@ diff --git i/src/build/SharedDeps.zig w/src/build/SharedDeps.zig
 index b1c084002..20a4161fa 100644
 --- i/src/build/SharedDeps.zig
 +++ w/src/build/SharedDeps.zig
-@@ -149,7 +149,7 @@ pub fn add(
+@@ -149,7 +149,7 @@
          );
- 
+
          if (b.systemIntegrationOption("freetype", .{})) {
 -            step.linkSystemLibrary2("bzip2", dynamic_link_opts);
 +            step.linkSystemLibrary2("bz2", dynamic_link_opts);

--- a/build-binary/patches/002-harfbuzz.patch
+++ b/build-binary/patches/002-harfbuzz.patch
@@ -2,7 +2,7 @@ diff --git i/pkg/harfbuzz/buffer.zig w/pkg/harfbuzz/buffer.zig
 index b97c1bef4..dbb37887a 100644
 --- i/pkg/harfbuzz/buffer.zig
 +++ w/pkg/harfbuzz/buffer.zig
-@@ -282,14 +282,6 @@ pub const ClusterLevel = enum(u2) {
+@@ -282,14 +282,6 @@
      /// the exact cluster values of each character, but is harder to use for
      /// clients, since clusters might appear in any order.
      characters = c.HB_BUFFER_CLUSTER_LEVEL_CHARACTERS,
@@ -15,5 +15,5 @@ index b97c1bef4..dbb37887a 100644
 -    /// algorithm.
 -    graphemes = c.HB_BUFFER_CLUSTER_LEVEL_GRAPHEMES,
  };
- 
+
  /// The hb_glyph_info_t is the structure that holds information about the


### PR DESCRIPTION
**IMPORTANT!**
This fix is for build against "tip" aka nightly, not release.

Problem (before)
<img width="1414" height="506" alt="image" src="https://github.com/user-attachments/assets/1a9e8447-c032-428f-9926-5b49d39c66de" />


Fix - local tests:
```sh
root@54f0557d5d56:/workspace/ghostty-1.2.3# patch -p1 < "$SCRIPT_DIR/patches/001-bzip2-to-bz2.patch"
(Stripping trailing CRs from patch; use --binary to disable.)
patching file src/build/SharedDeps.zig

root@54f0557d5d56:/workspace/ghostty-1.2.3# patch -p1 < "$SCRIPT_DIR/patches/002-harfbuzz.patch"
(Stripping trailing CRs from patch; use --binary to disable.)
patching file pkg/harfbuzz/buffer.zig
root@54f0557d5d56:/workspace/ghostty-1.2.3#
```

Fix - GH actions:
<img width="1362" height="571" alt="image" src="https://github.com/user-attachments/assets/53a818d8-a681-4aed-adc3-ab9d2c1dc240" />
