### PR TITLE
add sparky linux support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -67,7 +67,7 @@ case "$ID" in
     declare -A SPARKY_TO_DEBIAN=(
       ["8"]="trixie"
     )
-    SPARKY_VERSION=$(echo "$VERSION_ID" | cut -d'.' -f1)
+    SPARKY_VERSION="$VERSION_ID"
     DEBIAN_CODENAME=${SPARKY_TO_DEBIAN[$SPARKY_VERSION]}
     if [ -z "$DEBIAN_CODENAME" ]; then
       echo "This installer is not compatible with Sparky Linux $VERSION_ID"


### PR DESCRIPTION
This PR adds support for Sparky Linux, specifically version 8 which maps to debian Trixie.
This was motivated by https://github.com/mkasberg/ghostty-ubuntu/issues/176, a good first PR.

Although it doesn't fix the user's issue (Sparky 9 based on Debian forky), once ghostty is released for forky we can simply update the map.

This is my first open source PR, so let me know if I'm missing anything! I tried to stay consistent with the Kali switch case.