### PR TITLE
Prepare Binary Build for 1.3.0

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -37,7 +37,7 @@ jobs:
           ]
         }
       version_type: "release"
-      zig_version: "0.14.1"
+      zig_version: "0.15.2"
 
   release-ghostty:
     name: (Pre-)Release Ghostty Binary

--- a/build-binary/build-ghostty.sh
+++ b/build-binary/build-ghostty.sh
@@ -4,7 +4,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # https://ghostty.org/docs/install/build
-GHOSTTY_VERSION="1.2.3"
+GHOSTTY_VERSION="1.3.0"
 
 if [ "$1" == "tip" ]; then
   DEBIAN_SUFFIX="0~nightly"


### PR DESCRIPTION
Binary builds come from main. This prepares us for when Ghostty 1.3.0 is released in the next few weeks.