### PR TITLE
Reduce Test Builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
           "builds": [
             {"distro": "ubuntu", "version": "24.04"},
             {"distro": "ubuntu", "version": "25.10"},
-            {"distro": "debian", "version": "trixie"},
             {"distro": "debian", "version": "forky"}
           ],
           "arch": ["amd64"],


### PR DESCRIPTION
Seems excessive to test both Trixie and Forky on every PR since they use the same build process.