### PR TITLE
Make a Builder Image

### DIFF
--- a/.github/workflows/build-ppa-builder-image.yml
+++ b/.github/workflows/build-ppa-builder-image.yml
@@ -1,0 +1,69 @@
+name: Build PPA Builder Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      push:
+        description: 'Push images to registry (default: true)'
+        required: false
+        default: true
+        type: boolean
+
+env:
+  IMAGE_NAME: ${{ github.repository_owner }}/ghostty-ubuntu/ppa-builder
+
+jobs:
+  build:
+    name: Build PPA Builder (${{ matrix.codename }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ubuntu_version: "24.04"
+            codename: noble
+          - ubuntu_version: "25.10"
+            codename: questing
+          - ubuntu_version: "26.04"
+            codename: resolute
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        if: inputs.push
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ matrix.codename }}
+            type=raw,value=${{ matrix.ubuntu_version }}
+            type=sha,prefix=${{ matrix.codename }}-
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./build-ppa
+          push: ${{ inputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            CODENAME=${{ matrix.codename }}
+          cache-from: type=gha,scope=ppa-builder-${{ matrix.codename }}
+          cache-to: type=gha,mode=max,scope=ppa-builder-${{ matrix.codename }}

--- a/build-ppa/Dockerfile
+++ b/build-ppa/Dockerfile
@@ -1,0 +1,73 @@
+ARG CODENAME="noble"
+FROM ubuntu:${CODENAME}
+
+ARG CODENAME
+ENV CODENAME=${CODENAME}
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install base tools needed for PPA builds
+RUN apt-get update -qq && \
+    apt-get install -y -qq --no-install-recommends \
+        git \
+        devscripts \
+        build-essential \
+        debhelper \
+        wget \
+        minisign \
+        dput \
+        gnupg \
+        equivs \
+        software-properties-common && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Zig build dependencies (Zig is less likely to change, so install first for better caching)
+COPY zig0.15/debian/control /tmp/zig-control/
+RUN apt-get update -qq && \
+    apt-get install -y -qq --no-install-recommends \
+        chrpath \
+        cmake \
+        help2man \
+        libbsd-dev \
+        libclang-20-dev \
+        libclang-cpp20-dev \
+        libedit-dev \
+        libffi-dev \
+        liblld-20-dev \
+        libmd-dev \
+        libncurses-dev \
+        libunwind-dev \
+        libxml2-dev \
+        llvm-20-dev && \
+    cd /tmp/zig-control && \
+    mk-build-deps -i -t 'apt-get -y -qq --no-install-recommends' control && \
+    rm -f *.deb && \
+    rm -rf /tmp/zig-control /var/lib/apt/lists/*
+
+# Install Ghostty build dependencies (Ghostty is more likely to change, so install last)
+# Note: libgtk4-layer-shell-dev is not available on 24.04 (noble)
+COPY ghostty/debian/control /tmp/ghostty-control/
+RUN apt-get update -qq && \
+    apt-get install -y -qq --no-install-recommends \
+        pandoc \
+        pkgconf \
+        libadwaita-1-dev \
+        libbz2-dev \
+        libgtk-4-dev \
+        libonig-dev \
+        libxml2-utils && \
+    if [ "${CODENAME}" != "noble" ]; then \
+        apt-get install -y -qq --no-install-recommends libgtk4-layer-shell-dev; \
+    fi && \
+    cd /tmp/ghostty-control && \
+    mk-build-deps -i -t 'apt-get -y -qq --no-install-recommends' control && \
+    rm -f *.deb && \
+    rm -rf /tmp/ghostty-control /var/lib/apt/lists/*
+
+# Set up working directory
+WORKDIR /workspace
+
+LABEL org.opencontainers.image.source="https://github.com/mkasberg/ghostty-ubuntu"
+LABEL org.opencontainers.image.description="Pre-built PPA builder image for Ghostty and Zig packaging"
+LABEL org.opencontainers.image.licenses="MIT"


### PR DESCRIPTION
By using a custom image for our builds, we should be able to make them faster since we won't need to setup a fresh build environment every time.