### PR TITLE
Update Installer for 26.04

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,16 +22,16 @@ ARCH=$(dpkg --print-architecture)
 
 case "$ID" in
   ubuntu|pop|tuxedo|neon)
-    if [[ "$VERSION_ID" =~ ^(25.10|24.04)$ ]]; then
+    if [[ "$VERSION_ID" =~ ^(26.04|25.10|24.04)$ ]]; then
       SUFFIX="${ARCH}_${VERSION_ID}"
     else
       echo "This installer is not compatible with Ubuntu $VERSION_ID"
       exit 1
     fi
     ;;
-  
+
   elementary)
-    if [[ "$UBUNTU_VERSION_ID" =~ ^(25.10|24.04)$ ]]; then
+    if [[ "$UBUNTU_VERSION_ID" =~ ^(26.04|25.10|24.04)$ ]]; then
       SUFFIX="${ARCH}_${UBUNTU_VERSION_ID}"
     else
       echo "This installer is not compatible with Ubuntu $UBUNTU_VERSION_ID"
@@ -82,6 +82,7 @@ case "$ID" in
       SUFFIX="${ARCH}_${DEBIAN_CODENAME}"
     else
       declare -A SUPPORTED_VERSIONS=(
+        ["resolute"]="26.04"
         ["questing"]="25.10"
         ["noble"]="24.04"
       )
@@ -96,7 +97,7 @@ case "$ID" in
     ;;
 
   *)
-    if [[ "$UBUNTU_VERSION_ID" =~ ^(25.10|24.04)$ ]]; then
+    if [[ "$UBUNTU_VERSION_ID" =~ ^(26.04|25.10|24.04)$ ]]; then
       SUFFIX="${ARCH}_${UBUNTU_VERSION_ID}"
     else
       echo "This install script is not compatible with $ID."


### PR DESCRIPTION
Add 26.04 to our supported versions in the install script.

We're already building .debs for 26.04, we just need to update the install script to know about them.

Fixes #208