### PR TITLE
Fix FileNotFound

### DIFF
--- a/build-ppa/ghostty/debian/rules
+++ b/build-ppa/ghostty/debian/rules
@@ -17,7 +17,9 @@ override_dh_auto_install:
 		-Dpie=true \
 		-Demit-docs \
 		-Dversion-string=$(GHOSTTY_VERSION)
-	find $(CURDIR)/debian/ghostty -name '*.a' -delete
+
+override_dh_strip:
+	dh_strip -Xlibghostty-vt.a
 
 override_dh_install:
 	dh_install --sourcedir=debian/ghostty


### PR DESCRIPTION
The nightly build has had errors for a week or two.

We were deleting *.a due to errors with dh_strip since it was statically linked against things that don't exist in our package.

dff7d63378b43e4263756dec6f4b9ef7567b3e6d

But then later commits in upstream ghostty started depending on that file during the build. Instead, of deleting the file, we can exclude it from dh_strip.