### PR TITLE
Cleanup Build Timeouts

### DIFF
--- a/.github/workflows/binary-build.yml
+++ b/.github/workflows/binary-build.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   build-ghostty:
     name: Ghostty Binary
+    timeout-minutes: 12
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(inputs.build_matrix) }}

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -44,6 +44,7 @@ jobs:
     name: (Pre-)Release Ghostty Binary
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     needs: build-ghostty
     steps:
       - name: Download All Artifacts

--- a/.github/workflows/ppa-build-ghostty.yml
+++ b/.github/workflows/ppa-build-ghostty.yml
@@ -34,7 +34,7 @@ jobs:
   ghostty-build:
     name: Build Ghostty (${{ matrix.builds.codename }})
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 12
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(inputs.build_matrix) }}

--- a/.github/workflows/ppa-build-zig.yml
+++ b/.github/workflows/ppa-build-zig.yml
@@ -29,6 +29,7 @@ jobs:
   build:
     name: Build Zig (${{ matrix.builds.codename }})
     runs-on: ubuntu-latest
+    timeout-minutes: 8
     strategy:
       matrix: ${{ fromJson(inputs.build_matrix) }}
     container:


### PR DESCRIPTION
10 minutes is occasionally too short for the PPA Build, bump it to 12 minutes. Also add build timeouts where we were previously missing some.