### PR TITLE
Add nightly GitHub Release for tip builds

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,66 @@
+name: Nightly Release Ghostty Binary
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  build-nightly-ghostty:
+    name: Build Nightly
+    uses: ./.github/workflows/binary-build.yml
+    with:
+      build_matrix: |
+        {
+          "builds": [
+            {"distro": "ubuntu", "version": "24.04"},
+            {"distro": "ubuntu", "version": "25.10"},
+            {"distro": "ubuntu", "version": "26.04"},
+            {"distro": "debian", "version": "trixie"},
+            {"distro": "debian", "version": "forky"}
+          ],
+          "arch": ["amd64", "arm64"],
+          "include": [
+            {"arch": "amd64", "runner": "ubuntu-24.04"},
+            {"arch": "arm64", "runner": "ubuntu-24.04-arm"}
+          ]
+        }
+      version_type: "tip"
+      zig_version: "0.15.2"
+
+  release-nightly-ghostty:
+    name: Publish Nightly Release
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: build-nightly-ghostty
+    steps:
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: package-*
+          merge-multiple: true
+
+      - name: Publish Nightly Prerelease
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: nightly
+          name: Nightly
+          body: |
+            Automated nightly build from Ghostty `tip`. Updated daily.
+            **This is a prerelease — it may contain bugs.**
+
+            ### Install
+            ```bash
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/mkasberg/ghostty-ubuntu/HEAD/install-nightly.sh)"
+            ```
+          prerelease: true
+          make_latest: false
+          files: ghostty_*.deb
+          fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ methods below.
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/mkasberg/ghostty-ubuntu/HEAD/install.sh)"
 ```
 
+### Curl Install/Update (Nightly)
+
+:zap: To install the latest nightly build (built from Ghostty `tip`):
+
+```sh
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/mkasberg/ghostty-ubuntu/HEAD/install-nightly.sh)"
+```
+
+> [!WARNING]
+> Nightly builds may contain bugs. Use at your own risk.
+
 ### Manual Installation
 
 If you prefer to download and install the package manually instead of running the short script above, here are instructions.

--- a/install-nightly.sh
+++ b/install-nightly.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+# This is the nightly install script for ghostty-ubuntu (https://github.com/mkasberg/ghostty-ubuntu)
+#
+# Installs the latest nightly prerelease (built from Ghostty tip).
+#
+# /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/mkasberg/ghostty-ubuntu/HEAD/install-nightly.sh)"
+
+set -e
+
+echo "Installing/Updating Ghostty (nightly)..."
+
+source /etc/os-release
+ARCH=$(dpkg --print-architecture)
+
+case "$ID" in
+  ubuntu|pop|tuxedo|neon)
+    if [[ "$VERSION_ID" =~ ^(26.04|25.10|24.04)$ ]]; then
+      SUFFIX="${ARCH}_${VERSION_ID}"
+    else
+      echo "This installer is not compatible with Ubuntu $VERSION_ID"
+      exit 1
+    fi
+    ;;
+
+  elementary)
+    if [[ "$UBUNTU_VERSION_ID" =~ ^(26.04|25.10|24.04)$ ]]; then
+      SUFFIX="${ARCH}_${UBUNTU_VERSION_ID}"
+    else
+      echo "This installer is not compatible with Ubuntu $UBUNTU_VERSION_ID"
+      exit 1
+    fi
+    ;;
+
+  debian)
+    if [ "$VERSION_CODENAME" = "trixie" ]; then
+      SUFFIX="${ARCH}_${VERSION_CODENAME}"
+    else
+      echo "This installer is not compatible with Debian $VERSION_CODENAME"
+      exit 1
+    fi
+    ;;
+
+  kali)
+    # Map Kali versions to Debian codenames
+    declare -A KALI_TO_DEBIAN=(
+      ["2025"]="trixie"
+    )
+    KALI_YEAR=$(echo "$VERSION_ID" | cut -d'.' -f1)
+    DEBIAN_CODENAME=${KALI_TO_DEBIAN[$KALI_YEAR]}
+    if [ -z "$DEBIAN_CODENAME" ]; then
+      echo "This installer is not compatible with Kali Linux $VERSION_ID"
+      exit 1
+    fi
+    SUFFIX="${ARCH}_${DEBIAN_CODENAME}"
+    ;;
+
+  sparky)
+    # Map sparky versions to Debian codenames
+    declare -A SPARKY_TO_DEBIAN=(
+      ["8"]="trixie"
+    )
+    SPARKY_VERSION="$VERSION_ID"
+    DEBIAN_CODENAME=${SPARKY_TO_DEBIAN[$SPARKY_VERSION]}
+    if [ -z "$DEBIAN_CODENAME" ]; then
+      echo "This installer is not compatible with Sparky Linux $VERSION_ID"
+      exit 1
+    fi
+    SUFFIX="${ARCH}_${DEBIAN_CODENAME}"
+    ;;
+
+  linuxmint|zorin)
+    if [ "$DEBIAN_CODENAME" = "trixie" ]; then
+      # Handle LMDE (Linux Mint Debian Edition)
+      SUFFIX="${ARCH}_${DEBIAN_CODENAME}"
+    else
+      declare -A SUPPORTED_VERSIONS=(
+        ["resolute"]="26.04"
+        ["questing"]="25.10"
+        ["noble"]="24.04"
+      )
+
+      if [[ -n "${SUPPORTED_VERSIONS[$UBUNTU_CODENAME]}" ]]; then
+        SUFFIX="${ARCH}_${SUPPORTED_VERSIONS[$UBUNTU_CODENAME]}"
+      else
+        echo "This installer is not compatible with $ID $VERSION"
+        exit 1
+      fi
+    fi
+    ;;
+
+  *)
+    if [[ "$UBUNTU_VERSION_ID" =~ ^(26.04|25.10|24.04)$ ]]; then
+      SUFFIX="${ARCH}_${UBUNTU_VERSION_ID}"
+    else
+      echo "This install script is not compatible with $ID."
+      echo "If this distribution is based on Ubuntu, you can open an issue to add support to the install script."
+      echo "https://github.com/mkasberg/ghostty-ubuntu/issues/new?template=Blank+issue"
+      echo ""
+      echo "Please copy and paste the following information into the issue on GitHub to identify your distribution."
+      echo ""
+      cat /etc/os-release
+      echo ""
+      echo "In the mean time, you can try manually installing a .deb file from https://github.com/mkasberg/ghostty-ubuntu?tab=readme-ov-file#manual-installation"
+      exit 1
+    fi
+    ;;
+esac
+
+
+GHOSTTY_DEB_URL=$(
+   curl -s https://api.github.com/repos/mkasberg/ghostty-ubuntu/releases/tags/nightly | \
+   grep -oP "https://github.com/mkasberg/ghostty-ubuntu/releases/download/[^\s/]+/ghostty_[^\s/_]+_${SUFFIX}.deb"
+)
+if [[ -z "$GHOSTTY_DEB_URL" ]]; then
+  echo "Error: Failed to retrieve the .deb package URL from GitHub."
+  exit 1
+fi
+GHOSTTY_DEB_FILE=$(basename "$GHOSTTY_DEB_URL")
+
+echo "Downloading ${GHOSTTY_DEB_FILE}..."
+curl -LO "$GHOSTTY_DEB_URL"
+
+echo "Installing ${GHOSTTY_DEB_FILE}..."
+if [[ $EUID -ne 0 ]]; then
+  SUDO="sudo"
+else
+  SUDO=""
+fi
+$SUDO apt-get install -y ./"$GHOSTTY_DEB_FILE"
+rm "$GHOSTTY_DEB_FILE"


### PR DESCRIPTION
Add a dedicated workflow to publish nightly Ghostty tip .deb packages as a GitHub prerelease, along with an `install-nightly.sh` script for easy installation via curl.

Closes #223