### PR TITLE
Drop Questing and Tip Builds for Noble

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -25,16 +25,14 @@ jobs:
       build_matrix: |
         {
           "builds": [
-            {"distro": "ubuntu", "version": "24.04"},
-            {"distro": "ubuntu", "version": "25.10"},
             {"distro": "ubuntu", "version": "26.04"},
             {"distro": "debian", "version": "trixie"},
             {"distro": "debian", "version": "forky"}
           ],
           "arch": ["amd64", "arm64"],
           "include": [
-            {"arch": "amd64", "runner": "ubuntu-24.04"},
-            {"arch": "arm64", "runner": "ubuntu-24.04-arm"}
+            {"arch": "amd64", "runner": "ubuntu-26.04"},
+            {"arch": "arm64", "runner": "ubuntu-26.04-arm"}
           ]
         }
       version_type: "release"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,13 +19,11 @@ jobs:
       build_matrix: |
         {
           "builds": [
-            {"distro": "ubuntu", "version": "24.04"},
-            {"distro": "ubuntu", "version": "25.10"},
             {"distro": "ubuntu", "version": "26.04"}
           ],
           "arch": ["amd64"],
           "include": [
-            {"arch": "amd64", "runner": "ubuntu-24.04"}
+            {"arch": "amd64", "runner": "ubuntu-26.04"}
           ]
         }
       zig_version: "0.15.2"
@@ -42,8 +40,6 @@ jobs:
       build_matrix: |
         {
           "builds": [
-            {"codename": "noble", "container-image": "ubuntu:24.04"},
-            {"codename": "questing", "container-image": "ubuntu:25.10"},
             {"codename": "resolute", "container-image": "ubuntu:26.04"}
           ]
         }

--- a/.github/workflows/ppa-release-ghostty.yml
+++ b/.github/workflows/ppa-release-ghostty.yml
@@ -26,8 +26,6 @@ jobs:
       build_matrix: |
         {
           "builds": [
-            {"codename": "noble", "container-image": "ubuntu:24.04"},
-            {"codename": "questing", "container-image": "ubuntu:25.10"},
             {"codename": "resolute", "container-image": "ubuntu:26.04"}
           ]
         }

--- a/.github/workflows/ppa-release-zig.yml
+++ b/.github/workflows/ppa-release-zig.yml
@@ -28,7 +28,6 @@ jobs:
       build_matrix: |
         {
           "builds": [
-            {"codename": "questing", "container-image": "ubuntu:25.10"},
             {"codename": "resolute", "container-image": "ubuntu:26.04"}
           ]
         }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,12 @@ jobs:
       build_matrix: |
         {
           "builds": [
-            {"distro": "ubuntu", "version": "24.04"},
-            {"distro": "ubuntu", "version": "25.10"},
             {"distro": "ubuntu", "version": "26.04"},
             {"distro": "debian", "version": "forky"}
           ],
           "arch": ["amd64"],
           "include": [
-            {"arch": "amd64", "runner": "ubuntu-24.04"}
+            {"arch": "amd64", "runner": "ubuntu-26.04"}
           ]
         }
       zig_version: "0.15.2"
@@ -39,7 +37,6 @@ jobs:
       build_matrix: |
         {
           "builds": [
-            {"codename": "questing", "container-image": "ubuntu:25.10"},
             {"codename": "resolute", "container-image": "ubuntu:26.04"}
           ]
         }
@@ -53,7 +50,6 @@ jobs:
       build_matrix: |
         {
           "builds": [
-            {"codename": "questing", "container-image": "ubuntu:25.10"},
             {"codename": "resolute", "container-image": "ubuntu:26.04"}
           ]
         }

--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ via apt!
 We provide amd64 and and arm64 builds for:
 
  - Ubuntu 26.04 Resolute Raccoon
- - Ubuntu 25.10 Questing Quokka
- - Ubuntu 24.04 LTS Noble Numbat
+ - Ubuntu 24.04 LTS Noble Numbat (up to Ghostty 1.3.1)
  - Debian Forky
  - Debian Trixie
 
@@ -100,7 +99,7 @@ you can build the Docker image to get a build environment for any Ubuntu version
 (if you don't want to use your laptop as the build environment).
 
 ```bash
-docker build -t ghostty-ubuntu:latest --build-arg DISTRO=ubuntu --build-arg DISTRO_VERSION=25.10 --build-arg ZIG_VERSION=0.15.2 build-binary/
+docker build -t ghostty-ubuntu:latest --build-arg DISTRO=ubuntu --build-arg DISTRO_VERSION=26.04 --build-arg ZIG_VERSION=0.15.2 build-binary/
 ```
 
 Then you can use that build environment to produce a binary .deb package.

--- a/build-binary/Dockerfile
+++ b/build-binary/Dockerfile
@@ -1,4 +1,4 @@
-ARG DISTRO_VERSION="25.10"
+ARG DISTRO_VERSION="26.04"
 ARG DISTRO="ubuntu"
 FROM ${DISTRO}:${DISTRO_VERSION}
 
@@ -29,8 +29,8 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get -qq update && \
     libadwaita-1-dev \
     libgtk-4-dev \
     libxml2-utils && \
-    # Install libgtk4-layer-shell-dev but not on 24.04
-    if [ "$DISTRO" = "ubuntu" ] && [ "$DISTRO_VERSION" != "24.04" ]; then \
+    # Install libgtk4-layer-shell-dev but not on Debian
+    if [ "$DISTRO" = "ubuntu" ]; then \
         apt-get -qq -y --no-install-recommends install libgtk4-layer-shell-dev; \
     fi && \
     # Clean up for better caching

--- a/build-binary/build-ghostty.sh
+++ b/build-binary/build-ghostty.sh
@@ -56,7 +56,7 @@ QUILT_PATCHES=debian/patches quilt push -a || [ $? -eq 2 ]
 
 # Apply distro-specific patches to debian/ packaging
 case "$DISTRO_VERSION" in
-  "24.04" | "trixie" | "forky")
+  "trixie" | "forky")
     # Noble/trixie/forky: no libgtk4-layer-shell
     sed -i 's/-Doptimize=ReleaseFast/-Doptimize=ReleaseFast -fno-sys=gtk4-layer-shell/' debian/rules
     sed -i -e '/libgtk4-layer-shell0/d' -e '/libgtk4-layer-shell-dev/d' debian/control

--- a/build-ppa/AGENTS.md
+++ b/build-ppa/AGENTS.md
@@ -19,4 +19,4 @@ Ghostty PPA packaging source is at `build-ppa/ghostty`. Ghostty publishes a "tip
 
 Zig PPA packaging source is at `zig0.16/debian`. We also have some non-standard scripts in this build-ppa dir to fetch sources, do minor workarounds, and perform the PPA builds.
 
-Zig packages use the version scheme `UPSTREAMVERSION~ppaN-0~CODENAME1`. Zig 0.16 requires LLVM 21, so zig PPA builds only target questing and resolute (noble lacks LLVM 21).
+Zig packages use the version scheme `UPSTREAMVERSION~ppaN-0~CODENAME1`. Zig 0.16 requires LLVM 21, so zig PPA builds only target resolute (noble lacks LLVM 21).

--- a/build-ppa/build-ghostty.sh
+++ b/build-ppa/build-ghostty.sh
@@ -17,7 +17,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Default values
-CODENAME="questing"
+CODENAME="resolute"
 SIGN_PACKAGE=false
 VERSION="tip"
 PPA_VERSION="ppa2"
@@ -115,14 +115,7 @@ head -n5 "$CHANGELOG_FILE"
 
 # Build the source package in temp directory
 echo "Building source package..."
-if [ "$CODENAME" = "noble" ] || [ "$CODENAME" = "plucky" ]; then
-  # Maybe this?
-  # https://bugs.launchpad.net/ubuntu/+source/lintian/+bug/1959629
-  echo "Skipping lintian for noble/plucky"
-  DEBUILD_OPTIONS="--no-lintian"
-else
-  DEBUILD_OPTIONS=""
-fi
+DEBUILD_OPTIONS=""
 
 cd "$BUILD_DIR/$UPSTREAM_DIR"
 if [ "$SIGN_PACKAGE" = 'true' ]; then

--- a/build-ppa/build-zig.sh
+++ b/build-ppa/build-zig.sh
@@ -8,7 +8,7 @@
 #     -c CODENAME    Ubuntu codename (noble, questing, etc.)
 #     -s             Sign the package (sets SIGN_PACKAGE=true)
 #   codename: Ubuntu codename (noble, questing, etc.)
-#                Defaults to questing
+#                Defaults to resolute
 #
 
 set -e
@@ -17,7 +17,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Default values
-CODENAME="questing"
+CODENAME="resolute"
 SIGN_PACKAGE=false
 
 # Parse command line arguments
@@ -30,7 +30,7 @@ while getopts 'hc:s' opt; do
             echo "    -c CODENAME    Ubuntu codename (noble, questing, etc.)"
             echo "    -s             Sign the package (sets SIGN_PACKAGE=true)"
             echo "  codename: Ubuntu codename (noble, questing, etc.)"
-            echo "                   Defaults to questing"
+            echo "                   Defaults to resolute"
             exit 0
             ;;
         'c')
@@ -86,16 +86,6 @@ cp "$SCRIPT_DIR/${REPACK_TARBALL}" "$BUILD_DIR/"
 # Copy Debian packaging to temp directory
 echo "Copying Debian packaging..."
 cp -r "$SCRIPT_DIR/$PACKAGE_NAME/debian" "$BUILD_DIR/$UPSTREAM_DIR/"
-
-# Handle libxml2 dependency based on Ubuntu version
-echo "Adjusting libxml2 dependency for $CODENAME..."
-if [[ "$CODENAME" == "noble" ]]; then
-    echo "Using libxml2 for Ubuntu 24.04 (Noble) and earlier"
-    sed -i 's/libxml2-16/libxml2/' "$BUILD_DIR/$UPSTREAM_DIR/debian/control"
-else
-    echo "Using libxml2-16 for Ubuntu 25.10+ (Questing)"
-    # Keep libxml2-16 as is
-fi
 
 # Update changelog in temp directory
 CHANGELOG_FILE="$BUILD_DIR/$UPSTREAM_DIR/debian/changelog"

--- a/build-ppa/patch-for-dist.sh
+++ b/build-ppa/patch-for-dist.sh
@@ -14,7 +14,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Default values
-CODENAME="questing"
+CODENAME="resolute"
 
 while getopts 'hc:' opt; do
     case "$opt" in
@@ -37,16 +37,5 @@ while getopts 'hc:' opt; do
             ;;
     esac
 done
-
-if [ "$CODENAME" = "noble" ]; then
-  # Noble does not have libgtk4-layer-shell
-  # Build without that system lib, and remove the dependency on it.
-  sed -i 's/-Doptimize=ReleaseFast/-Doptimize=ReleaseFast -fno-sys=gtk4-layer-shell/' "$SCRIPT_DIR/ghostty/debian/rules"
-  sed -i '/libgtk4-layer-shell0/d' "$SCRIPT_DIR/ghostty/debian/control"
-  sed -i '/libgtk4-layer-shell-dev/d' "$SCRIPT_DIR/ghostty/debian/control"
-
-  # libicu76 is libicu74 in 24.04
-  sed -i 's/libicu76/libicu74/' "$SCRIPT_DIR/zig0.16/debian/control"
-fi
 
 echo "Done patching packaging source for $CODENAME"

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ ARCH=$(dpkg --print-architecture)
 
 case "$ID" in
   ubuntu|pop|tuxedo|neon)
-    if [[ "$VERSION_ID" =~ ^(26.04|25.10|24.04)$ ]]; then
+    if [[ "$VERSION_ID" =~ ^(26.04|24.04)$ ]]; then
       SUFFIX="${ARCH}_${VERSION_ID}"
     else
       echo "This installer is not compatible with Ubuntu $VERSION_ID"
@@ -31,7 +31,7 @@ case "$ID" in
     ;;
 
   elementary)
-    if [[ "$UBUNTU_VERSION_ID" =~ ^(26.04|25.10|24.04)$ ]]; then
+    if [[ "$UBUNTU_VERSION_ID" =~ ^(26.04|24.04)$ ]]; then
       SUFFIX="${ARCH}_${UBUNTU_VERSION_ID}"
     else
       echo "This installer is not compatible with Ubuntu $UBUNTU_VERSION_ID"
@@ -83,7 +83,6 @@ case "$ID" in
     else
       declare -A SUPPORTED_VERSIONS=(
         ["resolute"]="26.04"
-        ["questing"]="25.10"
         ["noble"]="24.04"
       )
 
@@ -97,7 +96,7 @@ case "$ID" in
     ;;
 
   *)
-    if [[ "$UBUNTU_VERSION_ID" =~ ^(26.04|25.10|24.04)$ ]]; then
+    if [[ "$UBUNTU_VERSION_ID" =~ ^(26.04|24.04)$ ]]; then
       SUFFIX="${ARCH}_${UBUNTU_VERSION_ID}"
     else
       echo "This install script is not compatible with $ID."


### PR DESCRIPTION
Ubuntu Questing (25.10) is end of life, and PPAs for it don't accept new uploads. We can stop building for it.

While we're at it, we can also begin removing support for Noble (24.04). Noble lacks LLVM 21 and therefore can't easily build ghostty tip anymore due to the zig0.16 dependency. The already-published builds for Ghostty 1.3.1 on Ubuntu 24.04 will continue working.