### PR TITLE
Use zig0.16 for Ghostty Builds

### DIFF
--- a/.github/workflows/binary-build.yml
+++ b/.github/workflows/binary-build.yml
@@ -11,7 +11,7 @@ on:
         description: 'Zig version to use'
         required: false
         type: string
-        default: "0.15.2"
+        default: "0.16.0"
       version_type:
         description: 'Version type to build: "tip" or "release"'
         required: false

--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -36,7 +36,7 @@ jobs:
           ]
         }
       version_type: "release"
-      zig_version: "0.15.2"
+      zig_version: "0.16.0"
 
   release-ghostty:
     name: (Pre-)Release Ghostty Binary

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
             {"arch": "amd64", "runner": "ubuntu-26.04"}
           ]
         }
-      zig_version: "0.15.2"
+      zig_version: "0.16.0"
       version_type: "tip"
 
   build-ghostty-ppa:

--- a/.github/workflows/ppa-build-ghostty.yml
+++ b/.github/workflows/ppa-build-ghostty.yml
@@ -34,7 +34,7 @@ jobs:
   ghostty-build:
     name: Build Ghostty (${{ matrix.builds.codename }})
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(inputs.build_matrix) }}

--- a/.github/workflows/ppa-build-zig.yml
+++ b/.github/workflows/ppa-build-zig.yml
@@ -29,7 +29,7 @@ jobs:
   build:
     name: Build Zig (${{ matrix.builds.codename }})
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(inputs.build_matrix) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
             {"arch": "amd64", "runner": "ubuntu-26.04"}
           ]
         }
-      zig_version: "0.15.2"
+      zig_version: "0.16.0"
       version_type: "tip"
 
   build-zig-ppa:

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ you can build the Docker image to get a build environment for any Ubuntu version
 (if you don't want to use your laptop as the build environment).
 
 ```bash
-docker build -t ghostty-ubuntu:latest --build-arg DISTRO=ubuntu --build-arg DISTRO_VERSION=26.04 --build-arg ZIG_VERSION=0.15.2 build-binary/
+docker build -t ghostty-ubuntu:latest --build-arg DISTRO=ubuntu --build-arg DISTRO_VERSION=26.04 --build-arg ZIG_VERSION=0.16.0 build-binary/
 ```
 
 Then you can use that build environment to produce a binary .deb package.

--- a/build-ppa/fetch-ghostty-orig-source.sh
+++ b/build-ppa/fetch-ghostty-orig-source.sh
@@ -56,7 +56,7 @@ fi
 tar -xzf "${GHOSTTY_TARBALL}"
 
 echo "Fetching zig cache..."
-sed -i 's/zig fetch/zig0.15 fetch/g' "${GHOSTTY_DIR}/nix/build-support/fetch-zig-cache.sh"
+sed -i 's/zig fetch/zig0.16 fetch/g' "${GHOSTTY_DIR}/nix/build-support/fetch-zig-cache.sh"
 ZIG_GLOBAL_CACHE_DIR="${GHOSTTY_DIR}/vendor-zig-cache" "${GHOSTTY_DIR}/nix/build-support/fetch-zig-cache.sh"
 find "${GHOSTTY_DIR}/vendor-zig-cache" -name '*.exe' -delete
 find "${GHOSTTY_DIR}/vendor-zig-cache" -name '*.dll' -delete

--- a/build-ppa/ghostty/debian/control
+++ b/build-ppa/ghostty/debian/control
@@ -13,7 +13,7 @@ Build-Depends: debhelper-compat (= 13),
                libgtk4-layer-shell-dev,
                libonig-dev,
                libxml2-utils,
-               zig0.15
+               zig0.16
 
 Package: ghostty
 Architecture: any

--- a/build-ppa/ghostty/debian/patches/001-bzip2-to-bz2.patch
+++ b/build-ppa/ghostty/debian/patches/001-bzip2-to-bz2.patch
@@ -1,13 +1,13 @@
 diff --git i/src/build/SharedDeps.zig w/src/build/SharedDeps.zig
-index b1c084002..20a4161fa 100644
+index 4877686c4..9bf298133 100644
 --- i/src/build/SharedDeps.zig
 +++ w/src/build/SharedDeps.zig
-@@ -149,7 +149,7 @@ pub fn add(
+@@ -251,7 +251,7 @@ pub fn add(
          );
  
          if (b.systemIntegrationOption("freetype", .{})) {
--            step.linkSystemLibrary2("bzip2", dynamic_link_opts);
-+            step.linkSystemLibrary2("bz2", dynamic_link_opts);
-             step.linkSystemLibrary2("freetype2", dynamic_link_opts);
+-            step.root_module.linkSystemLibrary("bzip2", dynamic_link_opts);
++            step.root_module.linkSystemLibrary("bz2", dynamic_link_opts);
+             step.root_module.linkSystemLibrary("freetype2", dynamic_link_opts);
          } else {
-             step.linkLibrary(freetype_dep.artifact("freetype"));
+             step.root_module.linkLibrary(freetype_dep.artifact("freetype"));

--- a/build-ppa/ghostty/debian/rules
+++ b/build-ppa/ghostty/debian/rules
@@ -2,7 +2,7 @@
 
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 GHOSTTY_VERSION ?= $(shell cat VERSION | sed 's/main+/ubuntu-nightly-/g')
-ZIG ?= zig0.15
+ZIG ?= zig0.16
 
 %:
 	dh $@


### PR DESCRIPTION
Now that we've built zig 0.16 for our PPA, we can use it to build Ghostty. This is currently required to build ghostty tip, and will be required for the next version of Ghostty.