### PR TITLE
feat: Add Debian forky to installer script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ case "$ID" in
     ;;
 
   debian)
-    if [ "$VERSION_CODENAME" = "trixie" ]; then
+    if [[ "$VERSION_CODENAME" =~ ^(trixie|forky)$ ]]; then
       SUFFIX="${ARCH}_${VERSION_CODENAME}"
     else
       echo "This installer is not compatible with Debian $VERSION_CODENAME"


### PR DESCRIPTION
Debian forky packages are builded but is not allowed in the installer script